### PR TITLE
Add Listeners API

### DIFF
--- a/docs/demo/demo-notebook.ipynb
+++ b/docs/demo/demo-notebook.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,27 +115,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "{\"__timestamp__\": \"2022-08-11T05:06:20.339412Z\", \"__schema__\": \"myapplication.org/example-event\", \"__schema_version__\": 1, \"__metadata_version__\": 1, \"name\": \"My Event\"}\n"
+      "{\"__timestamp__\": \"2022-08-11T22:46:22.248281Z\", \"__schema__\": \"myapplication.org/example-event\", \"__schema_version__\": 1, \"__metadata_version__\": 1, \"name\": \"My Event\"}\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'__timestamp__': '2022-08-11T05:06:20.339412Z',\n",
+       "{'__timestamp__': '2022-08-11T22:46:22.248281Z',\n",
        " '__schema__': 'myapplication.org/example-event',\n",
        " '__schema_version__': 1,\n",
        " '__metadata_version__': 1,\n",
        " 'name': 'My Event'}"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -145,6 +145,80 @@
     "    schema_id=\"myapplication.org/example-event\",\n",
     "    data={\n",
     "       \"name\": \"My Event\"\n",
+    "    }\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's demo adding a listener to the already registered event."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def my_listener(data):\n",
+    "    print(\"hello, from my_listener!\")\n",
+    "    print(data)\n",
+    "\n",
+    "logger.add_listener(schema_id=\"myapplication.org/example-event\", version=1, listener=my_listener)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we emit the event again, you'll see our listener \"sees\" the event and executes some code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"__timestamp__\": \"2022-08-11T22:46:28.947996Z\", \"__schema__\": \"myapplication.org/example-event\", \"__schema_version__\": 1, \"__metadata_version__\": 1, \"name\": \"My Event\"}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello world\n",
+      "EventListenerData(event_logger=<jupyter_events.logger.EventLogger object at 0x7fd07085dfd0>, schema_id='myapplication.org/example-event', version=1, data={'name': 'My Event'})\n",
+      "hello world\n",
+      "EventListenerData(event_logger=<jupyter_events.logger.EventLogger object at 0x7fd07085dfd0>, schema_id='myapplication.org/example-event', version=1, data={'name': 'My Event'})\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'__timestamp__': '2022-08-11T22:46:28.947996Z',\n",
+       " '__schema__': 'myapplication.org/example-event',\n",
+       " '__schema_version__': 1,\n",
+       " '__metadata_version__': 1,\n",
+       " 'name': 'My Event'}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "logger.emit(\n",
+    "    schema_id=\"myapplication.org/example-event\",\n",
+    "    version=1,\n",
+    "    data={\n",
+    "        \"name\": \"My Event\"\n",
     "    }\n",
     ")\n"
    ]

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -10,4 +10,5 @@ defining-schema
 configure
 application
 modifiers
+listeners
 ```

--- a/docs/user_guide/listeners.md
+++ b/docs/user_guide/listeners.md
@@ -9,17 +9,16 @@ Listeners can be used by extension authors to trigger custom logic every time an
 Define a listener function:
 
 ```python
-from jupyter_events.logger import EventListenerData
+from jupyter_events.logger import EventLogger
 
-
-def my_listener(event_data: EventListenerData) -> None:
+def my_listener(logger: EventLogger, schema_id: str, data: dict) -> None:
     print("hello, from my listener")
 ```
 
 Hook this listener to a specific event type:
 
 ```python
-event_logger.add_listener("http://event.jupyter.org/my-event", version=1, listener=my_listener)
+event_logger.add_listener("http://event.jupyter.org/my-event", listener=my_listener)
 ```
 
 Now, every time a `"http://event.jupyter.org/test"` event is emitted from the EventLogger, this listener will be called.

--- a/docs/user_guide/listeners.md
+++ b/docs/user_guide/listeners.md
@@ -1,0 +1,25 @@
+# Adding event listeners
+
+Event listeners are callback functions/methods that are executed when an event is emitted.
+
+Listeners can be used by extension authors to trigger custom logic every time an event occurs.
+
+## Basic usage
+
+Define a listener function:
+
+```python
+from jupyter_events.logger import EventListenerData
+
+
+def my_listener(event_data: EventListenerData) -> None:
+    print("hello, from my listener")
+```
+
+Hook this listener to a specific event type:
+
+```python
+event_logger.add_listener("http://event.jupyter.org/my-event", version=1, listener=my_listener)
+```
+
+Now, every time a `"http://event.jupyter.org/test"` event is emitted from the EventLogger, this listener will be called.

--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -257,7 +257,7 @@ class EventLogger(Configurable):
         if not callable(listener):
             raise TypeError("`listener` must be a callable")
 
-        if (schema_id, version) not in self.schemas:
+        if schema_id not in self.schemas:
             raise SchemaNotRegistered(
                 "The schema given for this listener has not be registered yet."
             )
@@ -279,7 +279,7 @@ class EventLogger(Configurable):
                     self._modified_listeners[schema_id].add(listener)
                     return
                 self._unmodified_listeners[schema_id].add(listener)
-            for (id, version) in self.listeners:
+            for id in self.listeners:
                 if schema_id is None or id == schema_id:
                     if modified:
                         self._modified_listeners[id].add(listener)

--- a/jupyter_events/schema_registry.py
+++ b/jupyter_events/schema_registry.py
@@ -28,7 +28,7 @@ class SchemaRegistry:
             )
         self._schemas[schema_obj.id] = schema_obj
 
-    def register(self, schema: Union[dict, str, EventSchema]):
+    def register(self, schema: Union[dict, str, EventSchema]) -> EventSchema:
         """Add a valid schema to the registry.
 
         All schemas are validated against the Jupyter Events meta-schema

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -24,19 +24,13 @@ async def test_listener_function(event_logger, schema):
     global listener_was_called
     listener_was_called = False
 
-    async def my_listener(
-        logger: EventLogger, schema_id: str, version: int, data: dict
-    ) -> None:
+    async def my_listener(logger: EventLogger, schema_id: str, data: dict) -> None:
         global listener_was_called
         listener_was_called = True  # type: ignore
 
     # Add the modifier
-    event_logger.add_listener(
-        schema_id=schema.id, version=schema.version, listener=my_listener
-    )
-    event_logger.emit(
-        schema_id=schema.id, version=schema.version, data={"prop": "hello, world"}
-    )
+    event_logger.add_listener(schema_id=schema.id, listener=my_listener)
+    event_logger.emit(schema_id=schema.id, data={"prop": "hello, world"})
     await event_logger.gather_listeners()
     assert listener_was_called
 
@@ -45,16 +39,15 @@ def test_bad_listener_function(event_logger, schema):
     logger = EventLogger()
 
     async def listener_with_extra_args(
-        logger: EventLogger, schema_id: str, version: int, data: dict, unknown_arg: dict
+        logger: EventLogger, schema_id: str, data: dict, unknown_arg: dict
     ) -> None:
         pass
 
     with pytest.raises(ListenerError):
         event_logger.add_listener(
             schema_id=schema.id,
-            version=schema.version,
             listener=listener_with_extra_args,
         )
 
     # Ensure no modifier was added.
-    assert len(logger.unmodified_listeners) == 0
+    assert len(logger._unmodified_listeners) == 0

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -1,0 +1,60 @@
+import pytest
+
+from jupyter_events.logger import EventLogger, ListenerError
+from jupyter_events.schema import EventSchema
+
+from .utils import SCHEMA_PATH
+
+
+@pytest.fixture
+def schema():
+    # Read schema from path.
+    schema_path = SCHEMA_PATH / "good" / "basic.yaml"
+    return EventSchema(schema=schema_path)
+
+
+@pytest.fixture
+def event_logger(schema):
+    logger = EventLogger()
+    logger.register_event_schema(schema)
+    return logger
+
+
+async def test_listener_function(event_logger, schema):
+    global listener_was_called
+    listener_was_called = False
+
+    async def my_listener(
+        logger: EventLogger, schema_id: str, version: int, data: dict
+    ) -> None:
+        global listener_was_called
+        listener_was_called = True  # type: ignore
+
+    # Add the modifier
+    event_logger.add_listener(
+        schema_id=schema.id, version=schema.version, listener=my_listener
+    )
+    event_logger.emit(
+        schema_id=schema.id, version=schema.version, data={"prop": "hello, world"}
+    )
+    await event_logger.gather_listeners()
+    assert listener_was_called
+
+
+def test_bad_listener_function(event_logger, schema):
+    logger = EventLogger()
+
+    async def listener_with_extra_args(
+        logger: EventLogger, schema_id: str, version: int, data: dict, unknown_arg: dict
+    ) -> None:
+        pass
+
+    with pytest.raises(ListenerError):
+        event_logger.add_listener(
+            schema_id=schema.id,
+            version=schema.version,
+            listener=listener_with_extra_args,
+        )
+
+    # Ensure no modifier was added.
+    assert len(logger.unmodified_listeners) == 0

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -1,3 +1,7 @@
+import asyncio
+import io
+import logging
+
 import pytest
 
 from jupyter_events.logger import EventLogger, ListenerError
@@ -33,11 +37,11 @@ async def test_listener_function(event_logger, schema):
     event_logger.emit(schema_id=schema.id, data={"prop": "hello, world"})
     await event_logger.gather_listeners()
     assert listener_was_called
+    # Check that the active listeners are cleaned up.
+    assert len(event_logger._active_listeners) == 0
 
 
-def test_bad_listener_function(event_logger, schema):
-    logger = EventLogger()
-
+async def test_bad_listener_function_signature(event_logger, schema):
     async def listener_with_extra_args(
         logger: EventLogger, schema_id: str, data: dict, unknown_arg: dict
     ) -> None:
@@ -50,4 +54,66 @@ def test_bad_listener_function(event_logger, schema):
         )
 
     # Ensure no modifier was added.
-    assert len(logger._unmodified_listeners) == 0
+    assert len(event_logger._unmodified_listeners[schema.id]) == 0
+
+
+async def test_listener_that_raises_exception(event_logger, schema):
+    # Get an application logger that will show the exception
+    app_log = event_logger.log
+    log_stream = io.StringIO()
+    h = logging.StreamHandler(log_stream)
+    app_log.addHandler(h)
+
+    async def listener_raise_exception(
+        logger: EventLogger, schema_id: str, data: dict
+    ) -> None:
+        raise Exception("This failed")
+
+    event_logger.add_listener(schema_id=schema.id, listener=listener_raise_exception)
+    event_logger.emit(schema_id=schema.id, data={"prop": "hello, world"})
+
+    await event_logger.gather_listeners()
+
+    # Check that the exception was printed to the logs
+    h.flush()
+    log_output = log_stream.getvalue()
+    assert "This failed" in log_output
+    # Check that the active listeners are cleaned up.
+    assert len(event_logger._active_listeners) == 0
+
+
+async def test_bad_listener_does_not_break_good_listener(event_logger, schema):
+    # Get an application logger that will show the exception
+    app_log = event_logger.log
+    log_stream = io.StringIO()
+    h = logging.StreamHandler(log_stream)
+    app_log.addHandler(h)
+
+    global listener_was_called
+    listener_was_called = False
+
+    async def listener_raise_exception(
+        logger: EventLogger, schema_id: str, data: dict
+    ) -> None:
+        raise Exception("This failed")
+
+    async def my_listener(logger: EventLogger, schema_id: str, data: dict) -> None:
+        global listener_was_called
+        listener_was_called = True  # type: ignore
+
+    # Add a bad listener and a good listener and ensure that
+    # emitting still works and the bad listener's exception is is logged.
+    event_logger.add_listener(schema_id=schema.id, listener=listener_raise_exception)
+    event_logger.add_listener(schema_id=schema.id, listener=my_listener)
+
+    event_logger.emit(schema_id=schema.id, data={"prop": "hello, world"})
+
+    await event_logger.gather_listeners()
+
+    # Check that the exception was printed to the logs
+    h.flush()
+    log_output = log_stream.getvalue()
+    assert "This failed" in log_output
+    assert listener_was_called
+    # Check that the active listeners are cleaned up.
+    assert len(event_logger._active_listeners) == 0

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -1,4 +1,3 @@
-import asyncio
 import io
 import logging
 


### PR DESCRIPTION
Fixes #7 

Add a simple API for "listening" to events and triggering a callback function when an event happens. The API is particularly useful for extension/plugin authors who might trigger extra logic when an event fires.

This _could_ be achieved by adding a handler and routing it to some stream, then listening to that stream. But that is quite complicated for most usecases. Also, handlers are really reserved for consumers of the eventloggers parent application. This listeners API is meant to be used by extension authors looking to hook into events and extend them.

Todo:
- [x] Unit tests
- [x] Documentation