### PR TITLE
Add a "modifiers" hook to allow extension authors to mutate/redact event data

### DIFF
--- a/docs/user_guide/application.md
+++ b/docs/user_guide/application.md
@@ -5,6 +5,7 @@ To begin using Jupyter Events in your Python application, create an instance of 
 ```python
 from jupyter_core.application import JupyterApp
 from jupyter_events import EventLogger
+from jupyter_events import Event
 
 
 class MyApplication(JupyterApp):
@@ -44,9 +45,11 @@ Call `.emit(...)` within the application to emit an instance of the event.
         ...
         # Emit event telling listeners that this event happened.
         self.eventlogger.emit(
-            id="myapplication.org/my-method",
-            version=1,
-            data={"msg": "Hello, world!"}
+            Event(
+                id="myapplication.org/my-method",
+                version=1,
+                data={"msg": "Hello, world!"}
+            )
         )
         # Do something else...
         ...

--- a/docs/user_guide/first-event.md
+++ b/docs/user_guide/first-event.md
@@ -39,15 +39,19 @@ handler = StreamHandler()
 logger.register_handler(handler)
 ```
 
-The logger knows about the event and where to send it; all that's left is to emit an instance of the event!
+The logger knows about the event and where to send it; all that's left is to emit an instance of the event! To to do this, import and create an instance of the `Event` dataclass, setting the `schema_id`, `version`, and `data` attributes and pass it to the `.emit` method.
 
 ```python
+from jupyter_events import Event
+
 logger.emit(
-   schema_id="myapplication.org/example-event",
-   version=1,
-   data={
-      "name": "My Event"
-   }
+   Event(
+      schema_id="myapplication.org/example-event",
+      version=1,
+      data={
+         "name": "My Event"
+      }
+   )
 )
 ```
 

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -9,4 +9,5 @@ event-schemas
 defining-schema
 configure
 application
+modifiers
 ```

--- a/docs/user_guide/modifiers.md
+++ b/docs/user_guide/modifiers.md
@@ -1,0 +1,21 @@
+# Modifying events in an application using `jupyter_events`
+
+If you're deploying a configurable application that uses Jupyter Events to emit events, you can extend the application's event logger to modify/mutate/redact incoming events before they are emitted. This is particularly useful if you need to mask, salt, or remove sensitive data from incoming event.
+
+To modify events, define a callable (function or method) that modifies the event data dictionary. This callable **must** follow an exact signature (type annotations required):
+
+```python
+def my_modifier(self, schema_id: str, version: id, data: dict) -> dict:
+    ...
+```
+
+The return value is the mutated data dictionary. This dictionary will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
+
+Next, add this modifier to the event logger using the `.add_modifier` method:
+
+```python
+logger = EventLogger()
+logger.add_modifier(my_modifier)
+```
+
+This method enforces the signature above and will raise a `ModifierError` if the signature does not match.

--- a/docs/user_guide/modifiers.md
+++ b/docs/user_guide/modifiers.md
@@ -5,11 +5,13 @@ If you're deploying a configurable application that uses Jupyter Events to emit 
 To modify events, define a callable (function or method) that modifies the event data dictionary. This callable **must** follow an exact signature (type annotations required):
 
 ```python
-def my_modifier(self, schema_id: str, version: id, data: dict) -> dict:
+from jupyter_events.logger import ModifierData
+
+def my_modifier(data: ModifierData) -> dict:
     ...
 ```
 
-The return value is the mutated data dictionary. This dictionary will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
+`ModifierData` is a dataclass with three attributes: `schema_id` (`str`), `version` (`int`), and `data` (`dict`). The return value is the mutated data dictionary. This dictionary will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
 
 Next, add this modifier to the event logger using the `.add_modifier` method:
 

--- a/docs/user_guide/modifiers.md
+++ b/docs/user_guide/modifiers.md
@@ -11,7 +11,7 @@ def my_modifier(data: ModifierData) -> dict:
     ...
 ```
 
-`ModifierData` is a dataclass with three attributes: `schema_id` (`str`), `version` (`int`), and `data` (`dict`). The return value is the mutated data dictionary. This dictionary will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
+`ModifierData` is a dataclass with three attributes: `schema_id` (`str`), `version` (`int`), and `event_data` (`dict`). The return value is the mutated data dictionary. This dictionary will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
 
 Next, add this modifier to the event logger using the `.add_modifier` method:
 

--- a/docs/user_guide/modifiers.md
+++ b/docs/user_guide/modifiers.md
@@ -5,13 +5,13 @@ If you're deploying a configurable application that uses Jupyter Events to emit 
 To modify events, define a callable (function or method) that modifies the event data dictionary. This callable **must** follow an exact signature (type annotations required):
 
 ```python
-from jupyter_events.logger import ModifierData
+from jupyter_events import Event
 
-def my_modifier(data: ModifierData) -> dict:
+def my_modifier(event: Event) -> Event:
     ...
 ```
 
-`ModifierData` is a dataclass with three attributes: `schema_id` (`str`), `version` (`int`), and `event_data` (`dict`). The return value is the mutated data dictionary. This dictionary will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
+`ModifierData` is a dataclass with three attributes: `schema_id` (`str`), `version` (`int`), and `data` (`dict`). The return value is the mutated `Event` object. This `Event` will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
 
 Next, add this modifier to the event logger using the `.add_modifier` method:
 

--- a/docs/user_guide/modifiers.md
+++ b/docs/user_guide/modifiers.md
@@ -11,7 +11,7 @@ def my_modifier(event: Event) -> Event:
     ...
 ```
 
-`ModifierData` is a dataclass with three attributes: `schema_id` (`str`), `version` (`int`), and `data` (`dict`). The return value is the mutated `Event` object. This `Event` will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
+`Event` is a dataclass with three attributes: `schema_id` (`str`), `version` (`int`), and `data` (`dict`). The return value is the mutated `Event` object. This `Event` will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
 
 Next, add this modifier to the event logger using the `.add_modifier` method:
 

--- a/jupyter_events/__init__.py
+++ b/jupyter_events/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from .dataclasses import Event, ModifierData
 from .logger import EVENTS_METADATA_VERSION, EventLogger
 from .schema import EventSchema

--- a/jupyter_events/__init__.py
+++ b/jupyter_events/__init__.py
@@ -1,3 +1,3 @@
-# Increment this version when the metadata included with each event
-# changes.
-EVENTS_METADATA_VERSION = 1
+from .dataclasses import Event, ModifierData
+from .logger import EVENTS_METADATA_VERSION, EventLogger
+from .schema import EventSchema

--- a/jupyter_events/__init__.py
+++ b/jupyter_events/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
-from .dataclasses import Event, ModifierData
+from .dataclasses import Event
 from .logger import EVENTS_METADATA_VERSION, EventLogger
 from .schema import EventSchema

--- a/jupyter_events/__init__.py
+++ b/jupyter_events/__init__.py
@@ -1,4 +1,3 @@
 # flake8: noqa
-from .dataclasses import Event
 from .logger import EVENTS_METADATA_VERSION, EventLogger
 from .schema import EventSchema

--- a/jupyter_events/dataclasses.py
+++ b/jupyter_events/dataclasses.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ModifierData:
+    schema_id: str
+    version: int
+    event_data: dict
+
+
+@dataclass
+class Event:
+    schema_id: str
+    version: int
+    data: dict

--- a/jupyter_events/dataclasses.py
+++ b/jupyter_events/dataclasses.py
@@ -1,8 +1,0 @@
-from dataclasses import dataclass
-
-
-@dataclass
-class Event:
-    schema_id: str
-    version: int
-    data: dict

--- a/jupyter_events/dataclasses.py
+++ b/jupyter_events/dataclasses.py
@@ -2,13 +2,6 @@ from dataclasses import dataclass
 
 
 @dataclass
-class ModifierData:
-    schema_id: str
-    version: int
-    event_data: dict
-
-
-@dataclass
 class Event:
     schema_id: str
     version: int

--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 import warnings
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import PurePath
 from typing import Callable, Union
@@ -28,6 +29,13 @@ class ModifierError(Exception):
     """An exception to raise when a modifier does not
     show the proper signature.
     """
+
+
+@dataclass
+class ModifierData:
+    schema_id: str
+    version: int
+    data: dict
 
 
 # Only show this warning on the first instance
@@ -156,7 +164,7 @@ class EventLogger(Configurable):
         # Now let's verify the function signature.
         signature = inspect.signature(modifier)
 
-        def modifier_signature(schema_id: str, version: int, data: dict) -> dict:
+        def modifier_signature(data: ModifierData) -> dict:
             """Signature to enforce"""
             return {}
 

--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -167,7 +167,11 @@ class EventLogger(Configurable):
             self.modifiers.append(modifier)
         except AssertionError:
             raise ModifierError(
-                f"Modifiers are required to follow an exact function/method signature. The signature should look like:\n\n\tdef my_modifier{expected_signature}:\n\nCheck that you are using type annotations for each argument and the return value."
+                "Modifiers are required to follow an exact function/method "
+                "signature. The signature should look like:"
+                f"\n\n\tdef my_modifier{expected_signature}:\n\n"
+                "Check that you are using type annotations for each argument "
+                "and the return value."
             )
 
     def emit(self, schema_id: str, version: int, data: dict, timestamp_override=None):

--- a/jupyter_events/schema_registry.py
+++ b/jupyter_events/schema_registry.py
@@ -38,6 +38,7 @@ class SchemaRegistry:
         if not isinstance(schema, EventSchema):
             schema = EventSchema(schema)
         self._add(schema)
+        return schema
 
     def get(self, id: str, version: int) -> EventSchema:
         """Fetch a given schema. If the schema is not found,

--- a/tests/schemas/good/user.yaml
+++ b/tests/schemas/good/user.yaml
@@ -1,0 +1,11 @@
+$id: http://event.jupyter.org/user
+version: 1
+title: User
+description: |
+  A User model.
+type: object
+properties:
+  username:
+    title: Username
+    description: Username.
+    type: string

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -9,7 +9,7 @@ from jsonschema.exceptions import ValidationError
 from traitlets import TraitError
 from traitlets.config.loader import PyFileConfigLoader
 
-from jupyter_events import Event, yaml
+from jupyter_events import yaml
 from jupyter_events.logger import EventLogger
 from jupyter_events.schema_registry import SchemaRegistryException
 
@@ -114,7 +114,9 @@ def test_timestamp_override():
 
     timestamp_override = datetime.utcnow() - timedelta(days=1)
     el.emit(
-        Event(schema_id="test/test", version=1, data={"something": "blah"}),
+        schema_id="test/test",
+        version=1,
+        data={"something": "blah"},
         timestamp_override=timestamp_override,
     )
     handler.flush()
@@ -142,7 +144,7 @@ def test_emit():
     el = EventLogger(handlers=[handler])
     el.register_event_schema(schema)
 
-    el.emit(Event(schema_id="test/test", version=1, data={"something": "blah"}))
+    el.emit(schema_id="test/test", version=1, data={"something": "blah"})
     handler.flush()
 
     event_capsule = json.loads(output.getvalue())
@@ -231,7 +233,7 @@ def test_emit_badschema():
 
     with pytest.raises(jsonschema.ValidationError):
         el.emit(
-            Event("test/test", 1, {"something": "blah", "status": "hi"})
+            schema_id="test/test", version=1, data={"something": "blah", "status": "hi"}
         )  # 'not-in-enum'
 
 
@@ -274,22 +276,18 @@ def test_unique_logger_instances():
     el1.allowed_schemas = ["test/test1"]
 
     el0.emit(
-        Event(
-            "test/test0",
-            1,
-            {
-                "something": "blah",
-            },
-        )
+        schema_id="test/test0",
+        version=1,
+        data={
+            "something": "blah",
+        },
     )
     el1.emit(
-        Event(
-            "test/test1",
-            1,
-            {
-                "something": "blah",
-            },
-        )
+        schema_id="test/test1",
+        version=1,
+        data={
+            "something": "blah",
+        },
     )
     handler0.flush()
     handler1.flush()

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -1,0 +1,101 @@
+import io
+import json
+import logging
+
+import pytest
+
+from jupyter_events.logger import EventLogger, ModifierError
+from jupyter_events.schema import EventSchema
+
+from .utils import SCHEMA_PATH
+
+
+def test_modifier():
+    # Read schema from path.
+    schema_path = SCHEMA_PATH / "good" / "user.yaml"
+    schema = EventSchema(schema=schema_path)
+
+    sink = io.StringIO()
+    handler = logging.StreamHandler(sink)
+
+    logger = EventLogger()
+    logger.register_handler(handler)
+    logger.register_event_schema(schema)
+
+    def redactor(data: dict = {}) -> dict:
+        if "username" in data:
+            data["username"] = "<masked>"
+        return data
+
+    # Add the modifier
+    logger.add_modifier(redactor)
+
+    logger.emit(schema.id, schema.version, {"username": "jovyan"})
+
+    # Flush from the handler
+    handler.flush()
+    # Read from the io
+    output = json.loads(sink.getvalue())
+    assert "username" in output
+    assert output["username"] == "<masked>"
+
+
+def test_modifier_class():
+    # Read schema from path.
+    schema_path = SCHEMA_PATH / "good" / "user.yaml"
+    schema = EventSchema(schema=schema_path)
+
+    sink = io.StringIO()
+    handler = logging.StreamHandler(sink)
+
+    logger = EventLogger()
+    logger.register_handler(handler)
+    logger.register_event_schema(schema)
+
+    class Redactor:
+        def redact(self, data: dict) -> dict:
+            if "username" in data:
+                data["username"] = "<masked>"
+            return data
+
+    redactor = Redactor()
+
+    # Add the modifier
+    logger.add_modifier(redactor.redact)
+
+    logger.emit(schema.id, schema.version, {"username": "jovyan"})
+
+    # Flush from the handler
+    handler.flush()
+    # Read from the io
+    output = json.loads(sink.getvalue())
+    assert "username" in output
+    assert output["username"] == "<masked>"
+
+
+def test_bad_modifier():
+    logger = EventLogger()
+    # Add a bad modifier
+
+    def bad_modifier(data: dict, unknown_arg: dict) -> dict:
+        return data
+
+    with pytest.raises(ModifierError):
+        logger.add_modifier(bad_modifier)
+
+    def bad_modifier_2(data: bool) -> dict:
+        pass
+
+    with pytest.raises(ModifierError):
+        logger.add_modifier(bad_modifier_2)
+
+    class Redactor:
+        def redact(self, data: dict, extra_args: dict) -> dict:
+            if "username" in data:
+                data["username"] = "<masked>"
+            return data
+
+    redactor = Redactor()
+
+    with pytest.raises(ModifierError):
+        logger.add_modifier(redactor.redact)

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -5,7 +5,6 @@ import logging
 import pytest
 
 from jupyter_events import Event
-from jupyter_events.dataclasses import ModifierData
 from jupyter_events.logger import EventLogger, ModifierError
 from jupyter_events.schema import EventSchema
 
@@ -24,11 +23,10 @@ def test_modifier_function():
     logger.register_handler(handler)
     logger.register_event_schema(schema)
 
-    def redactor(data: ModifierData) -> dict:
-        d = data.event_data
-        if "username" in d:
-            d["username"] = "<masked>"
-        return d
+    def redactor(event: Event) -> Event:
+        if "username" in event.data:
+            event.data["username"] = "<masked>"
+        return event
 
     # Add the modifier
     logger.add_modifier(redactor)
@@ -55,11 +53,10 @@ def test_modifier_method():
     logger.register_event_schema(schema)
 
     class Redactor:
-        def redact(self, data: ModifierData) -> dict:
-            d = data.event_data
-            if "username" in d:
-                d["username"] = "<masked>"
-            return d
+        def redact(self, event: Event) -> Event:
+            if "username" in event.data:
+                event.data["username"] = "<masked>"
+            return event
 
     redactor = Redactor()
 
@@ -79,8 +76,8 @@ def test_modifier_method():
 def test_bad_modifier_functions():
     logger = EventLogger()
 
-    def modifier_with_extra_args(data: ModifierData, unknown_arg: dict) -> dict:
-        return data.event_data
+    def modifier_with_extra_args(event: Event, unknown_arg: dict) -> Event:
+        return event.data
 
     with pytest.raises(ModifierError):
         logger.add_modifier(modifier_with_extra_args)
@@ -88,25 +85,15 @@ def test_bad_modifier_functions():
     # Ensure no modifier was added.
     assert len(logger.modifiers) == 0
 
-    def modifier_with_few_args(data: bool) -> dict:
-        pass
-
-    with pytest.raises(ModifierError):
-        logger.add_modifier(modifier_with_few_args)
-
-    # Ensure no modifier was added
-    assert len(logger.modifiers) == 0
-
 
 def test_bad_modifier_method():
     logger = EventLogger()
 
     class Redactor:
-        def redact(self, data: ModifierData, extra_args: dict) -> dict:
-            d = data.event_data
-            if "username" in d:
-                d["username"] = "<masked>"
-            return d
+        def redact(self, event: Event, extra_args: dict) -> Event:
+            if "username" in event.data:
+                event.data["username"] = "<masked>"
+            return event
 
     redactor = Redactor()
 
@@ -120,8 +107,8 @@ def test_bad_modifier_method():
 def test_modifier_without_annotations():
     logger = EventLogger()
 
-    def modifier_with_extra_args(data):
-        return data
+    def modifier_with_extra_args(event):
+        return event
 
     with pytest.raises(ModifierError):
         logger.add_modifier(modifier_with_extra_args)

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -77,7 +77,7 @@ def test_bad_modifier_functions():
     logger = EventLogger()
 
     def modifier_with_extra_args(event: Event, unknown_arg: dict) -> Event:
-        return event.data
+        return event
 
     with pytest.raises(ModifierError):
         logger.add_modifier(modifier_with_extra_args)


### PR DESCRIPTION
Addresses #11 

* Modifiers are added *before* the event is validated and emitted. That means, the mutated event are still required to follow the event schema.
* Modifiers are applied to *all* incoming events. Authors of modifiers can special case events inside their functions. This is slightly different than the listeners API in #10, which attaches listeners to specific events.
* This enforces a strict function/method signature (types included) for all modifiers added to the eventlogger. 