### PR TITLE
Add "redactors" API to enable easy redacting of (possibly sensitive) data

### DIFF
--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -9,4 +9,5 @@ event-schemas
 defining-schema
 configure
 application
+modifiers
 ```

--- a/docs/user_guide/modifiers.md
+++ b/docs/user_guide/modifiers.md
@@ -1,0 +1,21 @@
+# Modifying events in an application using `jupyter_events`
+
+If you're deploying a configurable application that uses Jupyter Events to emit events, you can extend the application's event logger to modify/mutate/redact incoming events before they are emitted. This is particularly useful if you need to mask, salt, or remove sensitive data from incoming event.
+
+To modify events, define a callable (function or method) that modifies the event data dictionary. This callable **must** follow an exact signature (type annotations required):
+
+```python
+def my_modifier(self, schema_id: str, version: id, data: dict) -> dict:
+    ...
+```
+
+The return value is the mutated data dictionary. This dictionary will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
+
+Next, add this modifier to the event logger using the `.add_modifier` method:
+
+```python
+logger = EventLogger()
+logger.add_modifier(my_modifier)
+```
+
+This method enforces the signature above and will raise a `ModifierError` if the signature does not match.

--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -167,7 +167,11 @@ class EventLogger(Configurable):
             self.modifiers.append(modifier)
         except AssertionError:
             raise ModifierError(
-                f"Modifiers are required to follow an exact function/method signature. The signature should look like:\n\n\tdef my_modifier{expected_signature}:\n\nCheck that you are using type annotations for each argument and the return value."
+                "Modifiers are required to follow an exact function/method "
+                "signature. The signature should look like:"
+                f"\n\n\tdef my_modifier{expected_signature}:\n\n"
+                "Check that you are using type annotations for each argument "
+                "and the return value."
             )
 
     def emit(self, schema_id: str, version: int, data: dict, timestamp_override=None):

--- a/jupyter_events/redactor.py
+++ b/jupyter_events/redactor.py
@@ -1,0 +1,131 @@
+"""A module with pre-defined, configurable Redactor objects
+that are useful for handling redacted data in a Jupyter
+Events logger.
+"""
+import re
+
+from traitlets import Dict, List, TraitType, Unicode, default
+from traitlets.config import Configurable
+
+
+class RedactedProperties(TraitType):
+    """A trait type for validating the `redacted_properties`
+    trait in Redactor objects.
+    """
+
+    info_text = (
+        "a list of properties to redact. This should be a list "
+        "of tuples with the form "
+        "(schema_id: str, version: int, property_name: str) "
+    )
+
+    def validate(self, obj, value):
+        try:
+            assert type(value) == list
+
+            for prop in value:
+                assert type(prop) == tuple
+                assert type(prop[0]) == str
+                assert type(prop[1]) == int
+                assert type(prop[2]) == str
+            return value
+        except AssertionError:
+            self.error(obj, value)
+
+
+class RedactedSchemas(TraitType):
+    """A trait type for validating the `redacted_properties`
+    trait in Redactor objects.
+    """
+
+    info_text = (
+        "a list of schemas to redact. This should be a list "
+        "of tuples with the form "
+        "(schema_id: str, version: int) "
+    )
+
+    def validate(self, obj, value):
+        try:
+            assert type(value) == list
+
+            for prop in value:
+                assert type(prop) == tuple
+                assert type(prop[0]) == str
+                assert type(prop[1]) == int
+            return value
+        except AssertionError:
+            self.error(obj, value)
+
+
+class BaseRedactor(Configurable):
+    """The base class for redactor objects that mutate
+    data in a Jupyter Events `EventLogger` object.
+    """
+
+    redacted_properties = RedactedProperties([]).tag(config=True)
+    redacted_patterns = List().tag(config=True)
+    redacted_schemas = RedactedSchemas([]).tag(config=True)
+
+    _mapping_redacted_properties = Dict()
+
+    @default("_mapping_redacted_properties")
+    def _default_mapping_redacted_properties(self):
+        """Building a mapping to properties for more efficient look-up."""
+        mapping_properties = {}
+        for (schema_id, version, key) in self.redacted_properties:
+            try:
+                mapping_properties[(schema_id, version)].append(key)
+            except KeyError:
+                mapping_properties[(schema_id, version)] = [key]
+        return mapping_properties
+
+    _regex_redacted_patterns = List()
+
+    @default("_regex_redacted_patterns")
+    def _default_regex_redacted_patterns(self):
+        return [re.compile(pat) for pat in self.redacted_patterns]
+
+    def _action(self, data: dict, key: str):
+        pass
+
+    def __call__(self, schema_id: str, version: int, data: dict) -> dict:
+        # If found in the redacted schemas, remove all data.
+        if (schema_id, version) in self.redacted_schemas:
+            for key in data:
+                self._action(data, key)
+            return data
+
+        # Build a list of keys to redact. We will iterate over
+        # these keys later, to avoid changing to dictionary size while iterating.
+        keys_to_redact = []
+        for key in data:
+            # First, check if this property is special cased in the redacted_properties
+            try:
+                if key in self._mapping_redacted_properties[(schema_id, version)]:
+                    keys_to_redact.append(key)
+            # If not, check if the property matches any redacted property patterns
+            except KeyError:
+                for pat in self._regex_redacted_patterns:
+                    # Compute a full match check:
+                    if pat.fullmatch(key):
+                        keys_to_redact.append(key)
+
+        for key in keys_to_redact:
+            self._action(data, key)
+        return data
+
+
+class RemovalRedactor(BaseRedactor):
+    """A redactor that deletes redacted data from an incoming event before it is emitted."""
+
+    def _action(self, data: dict, key: str):
+        data.pop(key)
+
+
+class MaskRedactor(BaseRedactor):
+    """A redactor that replaces redacted data in an incoming event with masking string."""
+
+    mask_string = Unicode("<masked>").tag(config=True)
+
+    def _action(self, data: dict, key: str):
+        data[key] = self.mask_string

--- a/jupyter_events/redactor.py
+++ b/jupyter_events/redactor.py
@@ -145,5 +145,4 @@ class MaskRedactor(BaseRedactor):
     mask_string = Unicode("<masked>").tag(config=True)
 
     def _action(self, data: dict, key: str):
-        print(data, key)
         data[key] = self.mask_string

--- a/tests/schemas/good/nested-user.yaml
+++ b/tests/schemas/good/nested-user.yaml
@@ -1,0 +1,35 @@
+$id: http://event.jupyter.org/nested-user
+version: 1
+title: Nested User
+description: |
+  A nested User model.
+type: object
+properties:
+  name:
+    title: Name
+    type: string
+  username:
+    title: Username
+    type: string
+  nemesis:
+    title: Nemesis
+    type: object
+    properties:
+      name:
+        title: Name
+        type: string
+      username:
+        title: Username
+        type: string
+  friends:
+    title: Friends
+    items:
+      type: object
+      title: Friend
+      properties:
+        name:
+          title: Friends Name
+          type: string
+        username:
+          title: Friends Username
+          type: string

--- a/tests/schemas/good/user.yaml
+++ b/tests/schemas/good/user.yaml
@@ -1,0 +1,11 @@
+$id: http://event.jupyter.org/user
+version: 1
+title: User
+description: |
+  A User model.
+type: object
+properties:
+  username:
+    title: Username
+    description: Username.
+    type: string

--- a/tests/schemas/good/user2.yaml
+++ b/tests/schemas/good/user2.yaml
@@ -1,4 +1,4 @@
-$id: http://event.jupyter.org/user
+$id: http://event.jupyter.org/user2
 version: 1
 title: User
 description: |

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -1,0 +1,101 @@
+import io
+import json
+import logging
+
+import pytest
+
+from jupyter_events.logger import EventLogger, ModifierError
+from jupyter_events.schema import EventSchema
+
+from .utils import SCHEMA_PATH
+
+
+def test_modifier():
+    # Read schema from path.
+    schema_path = SCHEMA_PATH / "good" / "user.yaml"
+    schema = EventSchema(schema=schema_path)
+
+    sink = io.StringIO()
+    handler = logging.StreamHandler(sink)
+
+    logger = EventLogger()
+    logger.register_handler(handler)
+    logger.register_event_schema(schema)
+
+    def redactor(data: dict = {}) -> dict:
+        if "username" in data:
+            data["username"] = "<masked>"
+        return data
+
+    # Add the modifier
+    logger.add_modifier(redactor)
+
+    logger.emit(schema.id, schema.version, {"username": "jovyan"})
+
+    # Flush from the handler
+    handler.flush()
+    # Read from the io
+    output = json.loads(sink.getvalue())
+    assert "username" in output
+    assert output["username"] == "<masked>"
+
+
+def test_modifier_class():
+    # Read schema from path.
+    schema_path = SCHEMA_PATH / "good" / "user.yaml"
+    schema = EventSchema(schema=schema_path)
+
+    sink = io.StringIO()
+    handler = logging.StreamHandler(sink)
+
+    logger = EventLogger()
+    logger.register_handler(handler)
+    logger.register_event_schema(schema)
+
+    class Redactor:
+        def redact(self, data: dict) -> dict:
+            if "username" in data:
+                data["username"] = "<masked>"
+            return data
+
+    redactor = Redactor()
+
+    # Add the modifier
+    logger.add_modifier(redactor.redact)
+
+    logger.emit(schema.id, schema.version, {"username": "jovyan"})
+
+    # Flush from the handler
+    handler.flush()
+    # Read from the io
+    output = json.loads(sink.getvalue())
+    assert "username" in output
+    assert output["username"] == "<masked>"
+
+
+def test_bad_modifier():
+    logger = EventLogger()
+    # Add a bad modifier
+
+    def bad_modifier(data: dict, unknown_arg: dict) -> dict:
+        return data
+
+    with pytest.raises(ModifierError):
+        logger.add_modifier(bad_modifier)
+
+    def bad_modifier_2(data: bool) -> dict:
+        pass
+
+    with pytest.raises(ModifierError):
+        logger.add_modifier(bad_modifier_2)
+
+    class Redactor:
+        def redact(self, data: dict, extra_args: dict) -> dict:
+            if "username" in data:
+                data["username"] = "<masked>"
+            return data
+
+    redactor = Redactor()
+
+    with pytest.raises(ModifierError):
+        logger.add_modifier(redactor.redact)

--- a/tests/test_redactor.py
+++ b/tests/test_redactor.py
@@ -1,0 +1,159 @@
+import io
+import json
+import logging
+
+import pytest
+
+from jupyter_events.logger import EventLogger
+from jupyter_events.redactor import MaskRedactor, RemovalRedactor
+from jupyter_events.schema import EventSchema
+
+from .utils import SCHEMA_PATH
+
+
+@pytest.fixture
+def schema1():
+    # Read schema from path.
+    schema_path = SCHEMA_PATH / "good" / "user.yaml"
+    return EventSchema(schema=schema_path)
+
+
+@pytest.fixture
+def schema2():
+    # Read schema from path.
+    schema_path = SCHEMA_PATH / "good" / "user2.yaml"
+    return EventSchema(schema=schema_path)
+
+
+@pytest.fixture
+def sink():
+    return io.StringIO()
+
+
+@pytest.fixture
+def handler(sink):
+    return logging.StreamHandler(sink)
+
+
+@pytest.fixture
+def event_logger(handler, schema1, schema2):
+    logger = EventLogger()
+    logger.register_handler(handler)
+    logger.register_event_schema(schema1)
+    logger.register_event_schema(schema2)
+    return logger
+
+
+@pytest.fixture
+def read_emitted_event(handler, sink):
+    def _read():
+        handler.flush()
+        output = json.loads(sink.getvalue())
+        # Clear the sink.
+        sink.truncate(0)
+        sink.seek(0)
+        return output
+
+    return _read
+
+
+def test_mask_pattern_redactor(schema1, event_logger, read_emitted_event):
+    redactor = MaskRedactor(redacted_patterns=["username"])
+
+    # Add the modifier
+    event_logger.add_modifier(redactor)
+    data = {"name": "Alice", "username": "jovyan", "hobby": "Coding"}
+    event_logger.emit(schema1.id, schema1.version, data)
+
+    output = read_emitted_event()
+    assert "username" in output
+    assert output["username"] == "<masked>"
+
+    # Check that everything else was unchanged
+    assert "hobby" in output
+    assert output["hobby"] == "Coding"
+    assert "name" in output
+    assert output["name"] == "Alice"
+
+
+def test_mask_properties_redactor(schema1, schema2, event_logger, read_emitted_event):
+    redactor = MaskRedactor(
+        redacted_properties=[(schema1.id, schema1.version, "username")]
+    )
+
+    # Add the modifier
+    event_logger.add_modifier(redactor)
+    data = {"name": "Alice", "username": "jovyan", "hobby": "Coding"}
+    event_logger.emit(schema1.id, schema1.version, data)
+
+    output = read_emitted_event()
+    assert "username" in output
+    assert output["username"] == "<masked>"
+    # Check that everything else was unchanged
+    assert "hobby" in output
+    assert output["hobby"] == "Coding"
+    assert "name" in output
+    assert output["name"] == "Alice"
+
+    # Emit an event from the second schema to make sure
+    # the properties were only applied to specific schema.
+    data = {"name": "Alice", "username": "jovyan", "hobby": "Coding"}
+    event_logger.emit(schema2.id, schema2.version, data)
+
+    output = read_emitted_event()
+
+    # Check that everything else was unchanged
+    assert "username" in output
+    assert output["username"] == "jovyan"
+    assert "hobby" in output
+    assert output["hobby"] == "Coding"
+    assert "name" in output
+    assert output["name"] == "Alice"
+
+
+def test_mask_schemas_redactor(schema1, schema2, event_logger, read_emitted_event):
+    redactor = MaskRedactor(redacted_schemas=[(schema1.id, 1)])
+
+    # Add the modifier
+    event_logger.add_modifier(redactor)
+    data = {"name": "Alice", "username": "jovyan", "hobby": "Coding"}
+    event_logger.emit(schema1.id, schema1.version, data)
+
+    output = read_emitted_event()
+    # Check that everything was changed
+    assert "username" in output
+    assert output["username"] == "<masked>"
+    assert "hobby" in output
+    assert output["hobby"] == "<masked>"
+    assert "name" in output
+    assert output["name"] == "<masked>"
+
+    # Emit an event from the second schema to make sure
+    # the properties were only applied to specific schema.
+    data = {"name": "Alice", "username": "jovyan", "hobby": "Coding"}
+    event_logger.emit(schema2.id, schema2.version, data)
+
+    output = read_emitted_event()
+    # Check that second event was unchanged
+    assert "username" in output
+    assert output["username"] == "jovyan"
+    assert "hobby" in output
+    assert output["hobby"] == "Coding"
+    assert "name" in output
+    assert output["name"] == "Alice"
+
+
+def test_removal_redactor(schema1, event_logger, read_emitted_event):
+    redactor = RemovalRedactor(redacted_patterns=["username"])
+
+    # Add the modifier
+    event_logger.add_modifier(redactor)
+
+    data = {"name": "Alice", "username": "jovyan", "hobby": "Coding"}
+    event_logger.emit(schema1.id, schema1.version, data)
+
+    # Flush from the handler
+    output = read_emitted_event()
+    assert "username" not in output
+    assert "hobby" in output
+    assert "name" in output


### PR DESCRIPTION
Building on https://github.com/jupyter/jupyter_events/pull/12, this adds a set of helpful "modifiers" that are specifically designed to redact data from events. These objects are configurable and easy to extend. 

An immediate use-case for these redactors is to redact sensitive data. As Jupyter applications begin to emit events, it's critical that we provide easy configuration to handle sensitive data under different deployment requirements. This API becomes the foundation for these applications or deployers to easily redact sensitive data in ways that suit their requirements.

The API is quite simple. To redact events, either configure or extend one of the provided `Redactor` classes. Redactors can act on whole schemas, individual properties within schemas, or all properties that match a certain (regex) pattern. They can be appended to the `EventLogger` through the `.add_modifier` API and chained with other modifiers to mutate events.

Over time, we can offer different types of Redactors as the need arises. In this PR, I've provided a `MaskRedactor` (just replaced redacted values with a configurable string) and a `RemovalRedactor` (deletes key/values from a schema). 

Todo: 
- [x] Handle nested properties
- [ ] documentation

