### PR TITLE
Remove (duplicate) version argument from API

### DIFF
--- a/docs/demo/demo-notebook.ipynb
+++ b/docs/demo/demo-notebook.ipynb
@@ -143,7 +143,6 @@
    "source": [
     "logger.emit(\n",
     "    schema_id=\"myapplication.org/example-event\",\n",
-    "    version=1,\n",
     "    data={\n",
     "       \"name\": \"My Event\"\n",
     "    }\n",

--- a/docs/user_guide/application.md
+++ b/docs/user_guide/application.md
@@ -44,13 +44,7 @@ Call `.emit(...)` within the application to emit an instance of the event.
         # Do something
         ...
         # Emit event telling listeners that this event happened.
-        self.eventlogger.emit(
-            Event(
-                id="myapplication.org/my-method",
-                version=1,
-                data={"msg": "Hello, world!"}
-            )
-        )
+        self.eventlogger.emit(schema_id="myapplication.org/my-method", data={"msg": "Hello, world!"})
         # Do something else...
         ...
 ```

--- a/docs/user_guide/first-event.md
+++ b/docs/user_guide/first-event.md
@@ -39,15 +39,13 @@ handler = StreamHandler()
 logger.register_handler(handler)
 ```
 
-The logger knows about the event and where to send it; all that's left is to emit an instance of the event! To to do this, import and create an instance of the `Event` dataclass, setting the `schema_id`, `version`, and `data` attributes and pass it to the `.emit` method.
+The logger knows about the event and where to send it; all that's left is to emit an instance of the event! To to do this, call the `.emit(...)` method and set the (required) `schema_id` and `data` arguments.
 
 ```python
 from jupyter_events import Event
 
 logger.emit(
-   Event(
       schema_id="myapplication.org/example-event",
-      version=1,
       data={
          "name": "My Event"
       }

--- a/docs/user_guide/modifiers.md
+++ b/docs/user_guide/modifiers.md
@@ -5,13 +5,11 @@ If you're deploying a configurable application that uses Jupyter Events to emit 
 To modify events, define a callable (function or method) that modifies the event data dictionary. This callable **must** follow an exact signature (type annotations required):
 
 ```python
-from jupyter_events import Event
-
-def my_modifier(event: Event) -> Event:
+def my_modifier(schema_id: str, data: dict) -> dict:
     ...
 ```
 
-`Event` is a dataclass with three attributes: `schema_id` (`str`), `version` (`int`), and `data` (`dict`). The return value is the mutated `Event` object. This `Event` will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
+The return value is the mutated event data (dict). This data will be validated and emitted _after_ it is modified, so it still must follow the event's schema.
 
 Next, add this modifier to the event logger using the `.add_modifier` method:
 

--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -111,7 +111,7 @@ class EventLogger(Configurable):
         Get this registered schema using the EventLogger.schema.get() method.
         """
         event_schema = self.schemas.register(schema)
-        key = event_schema.registry_key
+        key = event_schema.id
         self._modifiers[key] = set()
 
     def register_handler(self, handler: logging.Handler):
@@ -249,10 +249,8 @@ class EventLogger(Configurable):
 
         # Deep copy the data and modify the copy.
         modified_data = copy.deepcopy(data)
-        for modifier in self._modifiers[schema]:
-            modified_data = modifier(
-                schema_id=schema_id, data=modified_data
-            )
+        for modifier in self._modifiers[schema.id]:
+            modified_data = modifier(schema_id=schema_id, data=modified_data)
 
         # Process this event, i.e. validate and modify (in place)
         self.schemas.validate_event(schema_id, modified_data)

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -1,5 +1,4 @@
 import json
-
 from pathlib import PurePath
 from typing import Union
 

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -88,10 +88,6 @@ class EventSchema:
         """Schema's version."""
         return self._schema["version"]
 
-    @property
-    def registry_key(self) -> Tuple[str, int]:
-        return (self.id, self.version)
-
     def validate(self, data: dict) -> None:
         """Validate an incoming instance of this event schema."""
         self._validator.validate(data)

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -1,6 +1,7 @@
 import json
+
 from pathlib import PurePath
-from typing import Tuple, Union
+from typing import Union
 
 from jsonschema import validators
 from jsonschema.protocols import Validator

--- a/jupyter_events/schema_registry.py
+++ b/jupyter_events/schema_registry.py
@@ -13,21 +13,21 @@ class SchemaRegistry:
     def __init__(self, schemas: dict = None):
         self._schemas = schemas or {}
 
-    def __contains__(self, registry_key: Tuple[str, int]):
+    def __contains__(self, key: str):
         """Syntax sugar to check if a schema is found in the registry"""
-        return registry_key in self._schemas
+        return key in self._schemas
 
     def __repr__(self) -> str:
         return ",\n".join([str(s) for s in self._schemas.values()])
 
     def _add(self, schema_obj: EventSchema):
-        if schema_obj.registry_key in self._schemas:
+        if schema_obj.id in self._schemas:
             raise SchemaRegistryException(
                 f"The schema, {schema_obj.id} "
                 f"(version {schema_obj.version}), is already "
                 "registered. Try removing it and registering it again."
             )
-        self._schemas[schema_obj.registry_key] = schema_obj
+        self._schemas[schema_obj.id] = schema_obj
 
     def register(self, schema: Union[dict, str, EventSchema]):
         """Add a valid schema to the registry.
@@ -40,35 +40,33 @@ class SchemaRegistry:
         self._add(schema)
         return schema
 
-    def get(self, id: str, version: int) -> EventSchema:
+    def get(self, id: str) -> EventSchema:
         """Fetch a given schema. If the schema is not found,
         this will raise a KeyError.
         """
         try:
-            return self._schemas[(id, version)]
+            return self._schemas[id]
         except KeyError:
             raise KeyError(
-                f"The requested schema, {id} "
-                f"(version {version}), was not found in the "
+                f"The requested schema, {id}, was not found in the "
                 "schema registry. Are you sure it was previously registered?"
             )
 
-    def remove(self, id: str, version: int) -> None:
+    def remove(self, id: str) -> None:
         """Remove a given schema. If the schema is not found,
         this will raise a KeyError.
         """
         try:
-            del self._schemas[(id, version)]
+            del self._schemas[id]
         except KeyError:
             raise KeyError(
-                f"The requested schema, {id} "
-                f"(version {version}), was not found in the "
+                f"The requested schema, {id}, was not found in the "
                 "schema registry. Are you sure it was previously registered?"
             )
 
-    def validate_event(self, id: str, version: int, data: dict) -> None:
+    def validate_event(self, id: str, data: dict) -> None:
         """Validate an event against a schema within this
         registry.
         """
-        schema = self.get(id, version)
+        schema = self.get(id)
         schema.validate(data)

--- a/jupyter_events/schema_registry.py
+++ b/jupyter_events/schema_registry.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Union
 
 from .schema import EventSchema
 

--- a/jupyter_events/schema_registry.py
+++ b/jupyter_events/schema_registry.py
@@ -23,8 +23,7 @@ class SchemaRegistry:
     def _add(self, schema_obj: EventSchema):
         if schema_obj.id in self._schemas:
             raise SchemaRegistryException(
-                f"The schema, {schema_obj.id} "
-                f"(version {schema_obj.version}), is already "
+                f"The schema, {schema_obj.id}, is already "
                 "registered. Try removing it and registering it again."
             )
         self._schemas[schema_obj.id] = schema_obj

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -114,7 +114,11 @@ def test_timestamp_override():
 
     timestamp_override = datetime.utcnow() - timedelta(days=1)
 
-    el.emit("test/test", {"something": "blah"}, timestamp_override=timestamp_override)
+    el.emit(
+        schema_id="test/test",
+        data={"something": "blah"},
+        timestamp_override=timestamp_override,
+    )
     handler.flush()
     event_capsule = json.loads(output.getvalue())
     assert event_capsule["__timestamp__"] == timestamp_override.isoformat() + "Z"
@@ -141,8 +145,8 @@ def test_emit():
     el.register_event_schema(schema)
 
     el.emit(
-        "test/test",
-        {
+        schema_id="test/test",
+        data={
             "something": "blah",
         },
     )
@@ -233,7 +237,9 @@ def test_emit_badschema():
     el.allowed_schemas = ["test/test"]
 
     with pytest.raises(jsonschema.ValidationError):
-        el.emit("test/test", {"something": "blah", "status": "hi"})  # 'not-in-enum'
+        el.emit(
+            schema_id="test/test", data={"something": "blah", "status": "hi"}
+        )  # 'not-in-enum'
 
 
 def test_unique_logger_instances():
@@ -275,14 +281,14 @@ def test_unique_logger_instances():
     el1.allowed_schemas = ["test/test1"]
 
     el0.emit(
-        "test/test0",
-        {
+        schema_id="test/test0",
+        data={
             "something": "blah",
         },
     )
     el1.emit(
-        "test/test1",
-        {
+        schema_id="test/test1",
+        data={
             "something": "blah",
         },
     )

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -113,12 +113,8 @@ def test_timestamp_override():
     el.register_event_schema(schema)
 
     timestamp_override = datetime.utcnow() - timedelta(days=1)
-    el.emit(
-        schema_id="test/test",
-        version=1,
-        data={"something": "blah"},
-        timestamp_override=timestamp_override,
-    )
+
+    el.emit("test/test", {"something": "blah"}, timestamp_override=timestamp_override)
     handler.flush()
     event_capsule = json.loads(output.getvalue())
     assert event_capsule["__timestamp__"] == timestamp_override.isoformat() + "Z"
@@ -144,7 +140,12 @@ def test_emit():
     el = EventLogger(handlers=[handler])
     el.register_event_schema(schema)
 
-    el.emit(schema_id="test/test", version=1, data={"something": "blah"})
+    el.emit(
+        "test/test",
+        {
+            "something": "blah",
+        },
+    )
     handler.flush()
 
     event_capsule = json.loads(output.getvalue())
@@ -180,7 +181,7 @@ def test_register_event_schema(tmp_path):
     schema_file = tmp_path.joinpath("schema.yml")
     yaml.dump(schema, schema_file)
     el.register_event_schema(schema_file)
-    assert ("test/test", 1) in el.schemas
+    assert "test/test" in el.schemas
 
 
 def test_register_event_schema_object(tmp_path):
@@ -204,7 +205,7 @@ def test_register_event_schema_object(tmp_path):
     yaml.dump(schema, schema_file)
     el.register_event_schema(schema_file)
 
-    assert ("test/test", 1) in el.schemas
+    assert "test/test" in el.schemas
 
 
 def test_emit_badschema():
@@ -232,9 +233,7 @@ def test_emit_badschema():
     el.allowed_schemas = ["test/test"]
 
     with pytest.raises(jsonschema.ValidationError):
-        el.emit(
-            schema_id="test/test", version=1, data={"something": "blah", "status": "hi"}
-        )  # 'not-in-enum'
+        el.emit("test/test", {"something": "blah", "status": "hi"})  # 'not-in-enum'
 
 
 def test_unique_logger_instances():
@@ -276,16 +275,14 @@ def test_unique_logger_instances():
     el1.allowed_schemas = ["test/test1"]
 
     el0.emit(
-        schema_id="test/test0",
-        version=1,
-        data={
+        "test/test0",
+        {
             "something": "blah",
         },
     )
     el1.emit(
-        schema_id="test/test1",
-        version=1,
-        data={
+        "test/test1",
+        {
             "something": "blah",
         },
     )


### PR DESCRIPTION
We discussed this in last week's Jupyter Server meeting. The version argument is unnecessary in the API, since it's required in Jupyter's event schemas. This is redundant information, and easy to get out of sync. This PR removes all references to version from all method signatures and simplifies the API.