### PR TITLE
Add method to remove modifier

### DIFF
--- a/jupyter_events/schema_registry.py
+++ b/jupyter_events/schema_registry.py
@@ -28,6 +28,10 @@ class SchemaRegistry:
             )
         self._schemas[schema_obj.id] = schema_obj
 
+    @property
+    def schema_ids(self):
+        return self._schemas.keys()
+
     def register(self, schema: Union[dict, str, EventSchema]) -> EventSchema:
         """Add a valid schema to the registry.
 


### PR DESCRIPTION
https://github.com/jupyter/jupyter_events/pull/10 added listeners to the eventlogger. This PR adds a way to remove listeners.

