### PR TITLE
docs: wrap shell command in quotes

### DIFF
--- a/docs/user_guide/defining-schema.md
+++ b/docs/user_guide/defining-schema.md
@@ -47,7 +47,7 @@ When authoring a schema, how do you check if you schema is following the expecte
 First, install the CLI:
 
 ```
-pip install jupyter_events[cli]
+pip install "jupyter_events[cli]"
 ```
 
 Then, run the CLI against your schema:


### PR DESCRIPTION
`zsh` does not escape square brackets by default, and hence any CLI arguments with square brackets must be either escaped or wrapped in double quotes.