### PR TITLE
improve error messages for absent/invalid schema path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  node: system
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ or conda-forge:
 ```
 conda install -c conda-forge jupyter_events
 ```
+
+## Documentation
+
+Documentation is available at [jupyterlab.readthedocs.io](jupyterlab.readthedocs.io).

--- a/docs/user_guide/defining-schema.md
+++ b/docs/user_guide/defining-schema.md
@@ -7,11 +7,15 @@ All Jupyter Events schemas are valid [JSON schema](https://json-schema.org/) and
 A common pattern is to define these schemas in separate files and register them with an `EventLogger` using the `.register_event_schema(...)` method:
 
 ```python
-schema_filepath = "/path/to/schema.yaml"
+schema_filepath = Path("/path/to/schema.yaml")
 
 logger = EventLogger()
 logger.register_event_schema(schema_file)
 ```
+
+Note that a file path passed to `register_event_schema()` **must** be a Pathlib
+object. This is required for `register_event_schema()` to distinguish between
+file paths and schemas specified in a Python string.
 
 At a minimum, a valid Jupyter event schema requires the following keys:
 

--- a/jupyter_events/cli.py
+++ b/jupyter_events/cli.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import traceback
 
 import click
 from jsonschema import ValidationError
@@ -9,7 +10,8 @@ from rich.markup import escape
 from rich.padding import Padding
 from rich.style import Style
 
-from jupyter_events.schema import EventSchema, EventSchemaLoadingError
+from jupyter_events.schema import (EventSchema, EventSchemaFileAbsent,
+                                   EventSchemaLoadingError)
 
 console = Console()
 
@@ -28,18 +30,33 @@ def main():
 
 @click.command()
 @click.argument("schema")
-def validate(schema):
+def validate(schema: str):
     """Validate a SCHEMA against Jupyter Event's meta schema.
 
     SCHEMA can be a JSON/YAML string or filepath to a schema.
     """
     console.rule("Validating the following schema", style=Style(color="blue"))
-    # Soft load the schema without validating.
+
+    _schema = None
     try:
+        # attempt to read schema as a serialized string
         _schema = EventSchema._load_schema(schema)
     except EventSchemaLoadingError:
+        # pass here to avoid printing traceback of this exception if next block
+        # excepts
+        pass
+
+    # if not a serialized schema string, try to interpret it as a path to schema file
+    if _schema is None:
         schema_path = pathlib.Path(schema)
-        _schema = EventSchema._load_schema(schema_path)
+        try:
+            _schema = EventSchema._load_schema(schema_path)
+        except (EventSchemaLoadingError, EventSchemaFileAbsent) as e:
+            # no need for full tracestack for user error exceptions. just print
+            # the error message and return
+            console.log(f"[bold red]ERROR[/]: {e}")
+            return
+
     # Print what was found.
     schema_json = JSON(json.dumps(_schema))
     console.print(Padding(schema_json, (1, 0, 1, 4)))

--- a/jupyter_events/yaml.py
+++ b/jupyter_events/yaml.py
@@ -1,5 +1,5 @@
 # mypy: ignore-errors
-import pathlib
+from pathlib import Path
 
 from yaml import dump as ydump
 from yaml import load as yload
@@ -20,9 +20,10 @@ def dumps(stream):
 
 
 def load(fpath):
-    data = pathlib.Path(str(fpath)).read_text()
+    # coerce PurePath into Path, then read its contents
+    data = Path(str(fpath)).read_text()
     return loads(data)
 
 
 def dump(data, outpath):
-    pathlib.Path(outpath).write_text(dumps(data))
+    Path(outpath).write_text(dumps(data))

--- a/tests/schemas/bad/invalid.yaml
+++ b/tests/schemas/bad/invalid.yaml
@@ -1,0 +1,1 @@
+418 i'm a teapot

--- a/tests/schemas/good/basic.json
+++ b/tests/schemas/good/basic.json
@@ -1,0 +1,14 @@
+{
+  "$id": "http://event.jupyter.org/test",
+  "version": 1,
+  "title": "Simple Test Schema",
+  "description": "A simple schema for testing",
+  "type": "object",
+  "properties": {
+    "prop": {
+      "title": "Test Property",
+      "description": "Test property.",
+      "type": "string"
+    }
+  }
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,8 +1,13 @@
+import os
+from pathlib import Path
+
 import pytest
 from jsonschema.exceptions import ValidationError
 
 from jupyter_events import yaml
-from jupyter_events.schema import EventSchema, EventSchemaLoadingError
+from jupyter_events.schema import (EventSchema, EventSchemaFileAbsent,
+                                   EventSchemaLoadingError,
+                                   EventSchemaUnrecognized)
 from jupyter_events.validators import validate_schema
 
 from .utils import SCHEMA_PATH
@@ -11,6 +16,8 @@ BAD_SCHEMAS = [
     ["reserved-property.yaml", "Properties starting with 'dunder'"],
     ["nested-reserved-property.yaml", "Properties starting with 'dunder'"],
 ]
+
+GOOD_SCHEMAS = ["array.yaml", "nested-array.yaml", "basic.yaml"]
 
 
 @pytest.mark.parametrize("schema_file,validation_error_msg", BAD_SCHEMAS)
@@ -28,19 +35,51 @@ def test_bad_validations(schema_file, validation_error_msg):
     assert validation_error_msg in err.value.message
 
 
-GOOD_SCHEMAS = ["array.yaml", "nested-array.yaml", "basic.yaml"]
+def test_file_absent():
+    """Validation fails because file does not exist at path."""
+    with pytest.raises(EventSchemaFileAbsent):
+        EventSchema(Path("asdf.txt"))
+
+
+def test_string_intended_as_path():
+    """Ensure EventSchema returns a helpful error message if user passes a
+    string intended as a Path."""
+    expected_msg_contents = (
+        "Paths to schema files must be explicitly wrapped in a Pathlib object."
+    )
+    str_path = os.path.join(SCHEMA_PATH, "good", "some_schema.yaml")
+    with pytest.raises(EventSchemaLoadingError) as e:
+        EventSchema(str_path)
+
+    assert expected_msg_contents in str(e)
+
+
+def test_unrecognized_type():
+    """Validation fails because file is not of valid type."""
+    with pytest.raises(EventSchemaUnrecognized):
+        EventSchema(9001)
+
+
+def test_invalid_yaml():
+    """Validation fails because deserialized schema is not a dictionary."""
+    path = SCHEMA_PATH / "bad" / "invalid.yaml"
+    with pytest.raises(EventSchemaLoadingError):
+        EventSchema(path)
+
+
+def test_valid_json():
+    """Ensure EventSchema accepts JSON files."""
+    path = SCHEMA_PATH / "good" / "basic.json"
+    EventSchema(path)
 
 
 @pytest.mark.parametrize("schema_file", GOOD_SCHEMAS)
 def test_good_validations(schema_file):
-    """
-    Validation fails because the schema is missing
-    a redactionPolicies field.
-    """
+    """Ensure validation passes for good schemas."""
     # Read the schema file
     with open(SCHEMA_PATH / "good" / schema_file) as f:
         schema = yaml.loads(f)
-    # Assert that the schema files for a known reason.
+    # assert that no exception gets raised
     validate_schema(schema)
 
 


### PR DESCRIPTION
The error messages for passing a path without a file present or for passing a string path (rather than a Pathlib object) to `EventLogger#register_event_schema()` were very obtuse. This PR addresses that and improves error output for both cases. Also:

* updates documentation to specify that users must pass a Pathlib object to `register_event_schema()`.
* improve error catching and handling `_load_schema()`. adds new exceptions
    * raises exception when user loads un-deserializable (is there a better adjective for this?) schema file via passing a PurePath. This was previously uncaught by EventLogger, and was caught by JSON validator farther downstream instead.
* sets pre-commit node version to system
* adds docs link to README

## Before

Passing a path without a file:

```
dev-dsk-dlq-2b-55651109 % jupyter events validate asdf.txt
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Validating the following schema ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Traceback (most recent call last):
  File "/workplace/dlq/jupyter_events/jupyter_events/cli.py", line 39, in validate
    _schema = EventSchema._load_schema(schema)
  File "/workplace/dlq/jupyter_events/jupyter_events/schema.py", line 66, in _load_schema
    raise EventSchemaLoadingError(
jupyter_events.schema.EventSchemaLoadingError: When deserializing `schema`, we expected a dictionary to be returned but a <class 'str'> was returned instead. Double check the `schema` to make sure it is in the proper form.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dlq/anaconda3/envs/jserver-dev/bin/jupyter-events", line 8, in <module>
    sys.exit(main())
  File "/home/dlq/anaconda3/envs/jserver-dev/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/dlq/anaconda3/envs/jserver-dev/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/dlq/anaconda3/envs/jserver-dev/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/dlq/anaconda3/envs/jserver-dev/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/dlq/anaconda3/envs/jserver-dev/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/workplace/dlq/jupyter_events/jupyter_events/cli.py", line 42, in validate
    _schema = EventSchema._load_schema(schema_path)
  File "/workplace/dlq/jupyter_events/jupyter_events/schema.py", line 74, in _load_schema
    _schema = yaml.load(schema)
  File "/workplace/dlq/jupyter_events/jupyter_events/yaml.py", line 23, in load
    data = pathlib.Path(str(fpath)).read_text()
  File "/home/dlq/anaconda3/envs/jserver-dev/lib/python3.9/pathlib.py", line 1266, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/home/dlq/anaconda3/envs/jserver-dev/lib/python3.9/pathlib.py", line 1252, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/home/dlq/anaconda3/envs/jserver-dev/lib/python3.9/pathlib.py", line 1120, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: 'asdf.txt'
```

Passing a string path to `EventLogger#register_event_schema()`:

```
>>> logger = EventLogger()
>>> logger.register_event_schema("test_schema.json")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workplace/dlq/jupyter_events/jupyter_events/logger.py", line 134, in register_event_schema
    event_schema = self.schemas.register(schema)
  File "/workplace/dlq/jupyter_events/jupyter_events/schema_registry.py", line 42, in register
    schema = EventSchema(schema)
  File "/workplace/dlq/jupyter_events/jupyter_events/schema.py", line 44, in __init__
    _schema = self._load_schema(schema)
  File "/workplace/dlq/jupyter_events/jupyter_events/schema.py", line 66, in _load_schema
    raise EventSchemaLoadingError(
jupyter_events.schema.EventSchemaLoadingError: When deserializing `schema`, we expected a dictionary to be returned but a <class 'str'> was returned instead. Double check the `schema` to make sure it is in the proper form.
```

## After

Passing a path without a file:

```
dev-dsk-dlq-2b-55651109 % jupyter events validate asdf.txt
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Validating the following schema ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
[20:30:04] ERROR: File not present at path "asdf.txt".                                                                         
```

Passing a string path to `EventLogger#register_event_schema()`:

```
>>> from jupyter_events import EventLogger
>>> logger = EventLogger()
>>> logger.register_event_schema("test_schema.json")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workplace/dlq/jupyter_events/jupyter_events/logger.py", line 134, in register_event_schema
    event_schema = self.schemas.register(schema)
  File "/workplace/dlq/jupyter_events/jupyter_events/schema_registry.py", line 42, in register
    schema = EventSchema(schema)
  File "/workplace/dlq/jupyter_events/jupyter_events/schema.py", line 49, in __init__
    _schema = self._load_schema(schema)
  File "/workplace/dlq/jupyter_events/jupyter_events/schema.py", line 105, in _load_schema
    EventSchema._ensure_yaml_loaded(loaded_schema)
  File "/workplace/dlq/jupyter_events/jupyter_events/schema.py", line 74, in _ensure_yaml_loaded
    raise EventSchemaLoadingError(error_msg)
jupyter_events.schema.EventSchemaLoadingError: Could not deserialize schema into a dictionary. Paths to schema files must be explicitly wrapped in a Pathlib object.
```

## Notes

For some reason, pre-commit keeps failing my code while also not making any changes. Not sure if this will block the pipeline, so leaving a note here just in case.

```
(22-08-31 19:29:18) <1> [/workplace/dlq/jupyter_events]
dev-dsk-dlq-2b-55651109 % pre-commit
fix end of files.........................................................Passed
check for case conflicts.................................................Passed
check that executables have shebangs.................(no files to check)Skipped
fix requirements.txt.................................(no files to check)Skipped
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check toml...........................................(no files to check)Skipped
check yaml...............................................................Passed
debug statements (python)................................................Passed
forbid new submodules................................(no files to check)Skipped
check builtin type constructor use.......................................Passed
trim trailing whitespace.................................................Passed
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted jupyter_events/cli.py
reformatted tests/test_schema.py

All done! ✨ 🍰 ✨
2 files reformatted, 2 files left unchanged.

isort....................................................................Failed
- hook id: isort
- files were modified by this hook

Fixing /workplace/dlq/jupyter_events/jupyter_events/cli.py
Fixing /workplace/dlq/jupyter_events/tests/test_schema.py

mypy.....................................................................Passed
prettier.................................................................Passed
pyupgrade................................................................Passed
```
