### PR TITLE
Add pytest plugin for testing events in other libraries

### DIFF
--- a/jupyter_events/pytest_plugin.py
+++ b/jupyter_events/pytest_plugin.py
@@ -20,12 +20,13 @@ def jp_event_handler(jp_event_sink):
 
 
 @pytest.fixture
-def jp_read_emitted_event(jp_event_handler, jp_event_sink):
-    """Reads the last event emitted by the event_logger fixture"""
+def jp_read_emitted_events(jp_event_handler, jp_event_sink):
+    """Reads list of events since last time it was called."""
 
     def _read():
         jp_event_handler.flush()
-        output = json.loads(jp_event_sink.getvalue())
+        lines = jp_event_sink.getvalue().strip().split("\n")
+        output = [json.loads(item) for item in lines]
         # Clear the sink.
         jp_event_sink.truncate(0)
         jp_event_sink.seek(0)

--- a/jupyter_events/pytest_plugin.py
+++ b/jupyter_events/pytest_plugin.py
@@ -1,0 +1,56 @@
+import io
+import json
+import logging
+
+import pytest
+
+from jupyter_events import EventLogger
+
+
+@pytest.fixture
+def jp_event_sink():
+    """A stream for capture events."""
+    return io.StringIO()
+
+
+@pytest.fixture
+def jp_event_handler(jp_event_sink):
+    """A logging handler that captures any events emitted by the event handler"""
+    return logging.StreamHandler(jp_event_sink)
+
+
+@pytest.fixture
+def jp_read_emitted_event(jp_event_handler, jp_event_sink):
+    """Reads the last event emitted by the event_logger fixture"""
+
+    def _read():
+        jp_event_handler.flush()
+        output = json.loads(jp_event_sink.getvalue())
+        # Clear the sink.
+        jp_event_sink.truncate(0)
+        jp_event_sink.seek(0)
+        return output
+
+    return _read
+
+
+@pytest.fixture
+def jp_event_schemas():
+    """A list of schema references.
+
+    Each item should be one of the following:
+    - string of serialized JSON/YAML content representing a schema
+    - a pathlib.Path object pointing to a schema file on disk
+    - a dictionary with the schema data.
+    """
+    return []
+
+
+@pytest.fixture
+def jp_event_logger(jp_event_handler, jp_event_schemas):
+    """A pre-configured event logger for tests."""
+    logger = EventLogger()
+    for schema in jp_event_schemas:
+        logger.register_event_schema(schema)
+    logger.register_handler(handler=jp_event_handler)
+    return logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,9 @@ default = ""
 [[tool.tbump.field]]
 name = "release"
 default = ""
+
+[tool.pytest.ini_options]
+addopts = "-raXs --durations 10 --color=yes --doctest-modules"
+testpaths = [
+    "tests/"
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["jupyter_events.pytest_plugin"]

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -17,13 +17,12 @@ def schema():
 
 
 @pytest.fixture
-def event_logger(schema):
-    logger = EventLogger()
-    logger.register_event_schema(schema)
-    return logger
+def jp_event_schemas(schema):
+    return [schema]
 
 
-async def test_listener_function(event_logger, schema):
+async def test_listener_function(jp_event_logger, schema):
+    event_logger = jp_event_logger
     global listener_was_called
     listener_was_called = False
 
@@ -40,7 +39,8 @@ async def test_listener_function(event_logger, schema):
     assert len(event_logger._active_listeners) == 0
 
 
-async def test_remove_listener_function(event_logger, schema):
+async def test_remove_listener_function(jp_event_logger, schema):
+    event_logger = jp_event_logger
     global listener_was_called
     listener_was_called = False
 
@@ -62,7 +62,9 @@ async def test_remove_listener_function(event_logger, schema):
     assert len(event_logger._unmodified_listeners[schema.id]) == 0
 
 
-async def test_bad_listener_function_signature(event_logger, schema):
+async def test_bad_listener_function_signature(jp_event_logger, schema):
+    event_logger = jp_event_logger
+
     async def listener_with_extra_args(
         logger: EventLogger, schema_id: str, data: dict, unknown_arg: dict
     ) -> None:
@@ -78,7 +80,9 @@ async def test_bad_listener_function_signature(event_logger, schema):
     assert len(event_logger._unmodified_listeners[schema.id]) == 0
 
 
-async def test_listener_that_raises_exception(event_logger, schema):
+async def test_listener_that_raises_exception(jp_event_logger, schema):
+    event_logger = jp_event_logger
+
     # Get an application logger that will show the exception
     app_log = event_logger.log
     log_stream = io.StringIO()
@@ -103,7 +107,9 @@ async def test_listener_that_raises_exception(event_logger, schema):
     assert len(event_logger._active_listeners) == 0
 
 
-async def test_bad_listener_does_not_break_good_listener(event_logger, schema):
+async def test_bad_listener_does_not_break_good_listener(jp_event_logger, schema):
+    event_logger = jp_event_logger
+
     # Get an application logger that will show the exception
     app_log = event_logger.log
     log_stream = io.StringIO()

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -18,7 +18,7 @@ def jp_event_schemas(schema):
     return [schema]
 
 
-def test_modifier_function(schema, jp_event_logger, jp_read_emitted_event):
+def test_modifier_function(schema, jp_event_logger, jp_read_emitted_events):
     event_logger = jp_event_logger
 
     def redactor(schema_id: str, data: dict) -> dict:
@@ -29,12 +29,12 @@ def test_modifier_function(schema, jp_event_logger, jp_read_emitted_event):
     # Add the modifier
     event_logger.add_modifier(modifier=redactor)
     event_logger.emit(schema_id=schema.id, data={"username": "jovyan"})
-    output = jp_read_emitted_event()
+    output = jp_read_emitted_events()[0]
     assert "username" in output
     assert output["username"] == "<masked>"
 
 
-def test_modifier_method(schema, jp_event_logger, jp_read_emitted_event):
+def test_modifier_method(schema, jp_event_logger, jp_read_emitted_events):
     event_logger = jp_event_logger
 
     class Redactor:
@@ -49,7 +49,7 @@ def test_modifier_method(schema, jp_event_logger, jp_read_emitted_event):
     event_logger.add_modifier(modifier=redactor.redact)
 
     event_logger.emit(schema_id=schema.id, data={"username": "jovyan"})
-    output = jp_read_emitted_event()
+    output = jp_read_emitted_events()[0]
     assert "username" in output
     assert output["username"] == "<masked>"
 
@@ -93,7 +93,7 @@ def test_modifier_without_annotations():
         logger.add_modifier(modifier=modifier_with_extra_args)
 
 
-def test_remove_modifier(schema, jp_event_logger, jp_read_emitted_event):
+def test_remove_modifier(schema, jp_event_logger, jp_read_emitted_events):
     event_logger = jp_event_logger
 
     def redactor(schema_id: str, data: dict) -> dict:
@@ -107,7 +107,7 @@ def test_remove_modifier(schema, jp_event_logger, jp_read_emitted_event):
     assert len(event_logger._modifiers) == 1
 
     event_logger.emit(schema_id=schema.id, data={"username": "jovyan"})
-    output = jp_read_emitted_event()
+    output = jp_read_emitted_events()[0]
 
     assert "username" in output
     assert output["username"] == "<masked>"
@@ -115,7 +115,7 @@ def test_remove_modifier(schema, jp_event_logger, jp_read_emitted_event):
     event_logger.remove_modifier(modifier=redactor)
 
     event_logger.emit(schema_id=schema.id, data={"username": "jovyan"})
-    output = jp_read_emitted_event()
+    output = jp_read_emitted_events()[0]
 
     assert "username" in output
     assert output["username"] == "jovyan"

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -1,7 +1,3 @@
-import io
-import json
-import logging
-
 import pytest
 
 from jupyter_events.logger import EventLogger, ModifierError


### PR DESCRIPTION
Pulls out of the pytest fixtures that are generally useful and makes them available through a pytest plugin.