### PR TITLE
Set version floor on jsonchema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "jsonschema",
+    "jsonschema>=4.3.0",
     "python-json-logger",
     "pyyaml",
     "traitlets",


### PR DESCRIPTION
jupyter-events uses the `Validator` class from the `jsonschema.protocols` package, which didn't exist until version `4.3.0`.  Attempts to install jupyter_events into environments where `jsonschema < 4.3.0` result in the following:
```
$ jupyter lab       
Traceback (most recent call last):
  File "/opt/miniconda3/envs/server-dev/bin/jupyter-lab", line 5, in <module>
    from jupyterlab.labapp import main
  File "/opt/miniconda3/envs/server-dev/lib/python3.9/site-packages/jupyterlab/labapp.py", line 13, in <module>
    from jupyter_server.serverapp import flags
  File "/opt/miniconda3/envs/server-dev/lib/python3.9/site-packages/jupyter_server/serverapp.py", line 64, in <module>
    from jupyter_events.logger import EventLogger
  File "/opt/miniconda3/envs/server-dev/lib/python3.9/site-packages/jupyter_events/__init__.py", line 2, in <module>
    from .logger import EVENTS_METADATA_VERSION, EventLogger
  File "/opt/miniconda3/envs/server-dev/lib/python3.9/site-packages/jupyter_events/logger.py", line 18, in <module>
    from .schema_registry import SchemaRegistry
  File "/opt/miniconda3/envs/server-dev/lib/python3.9/site-packages/jupyter_events/schema_registry.py", line 3, in <module>
    from .schema import EventSchema
  File "/opt/miniconda3/envs/server-dev/lib/python3.9/site-packages/jupyter_events/schema.py", line 6, in <module>
    from jsonschema.protocols import Validator
ModuleNotFoundError: No module named 'jsonschema.protocols'
```
This pull request adjusts the floor for `jsonschema` such that it's installation results in a `jsonschema` upgrade...
```
$ pip install dist/jupyter_events-0.5.0.dev0-py3-none-any.whl
Requirement already satisfied: python-json-logger in /opt/miniconda3/envs/server-dev/lib/python3.9/site-packages (from jupyter-events==0.5.0.dev0) (2.0.2)
Collecting jsonschema>=4.3.0
  Using cached jsonschema-4.15.0-py3-none-any.whl (82 kB)
Requirement already satisfied: pyyaml in /opt/miniconda3/envs/server-dev/lib/python3.9/site-packages (from jupyter-events==0.5.0.dev0) (6.0)
Requirement already satisfied: traitlets in /opt/miniconda3/envs/server-dev/lib/python3.9/site-packages (from jupyter-events==0.5.0.dev0) (5.3.0)
Requirement already satisfied: attrs>=17.4.0 in /opt/miniconda3/envs/server-dev/lib/python3.9/site-packages (from jsonschema>=4.3.0->jupyter-events==0.5.0.dev0) (21.4.0)
Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in /opt/miniconda3/envs/server-dev/lib/python3.9/site-packages (from jsonschema>=4.3.0->jupyter-events==0.5.0.dev0) (0.18.1)
jupyter-events is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
Installing collected packages: jsonschema
  Attempting uninstall: jsonschema
    Found existing installation: jsonschema 4.2.1
    Uninstalling jsonschema-4.2.1:
      Successfully uninstalled jsonschema-4.2.1
Successfully installed jsonschema-4.15.0
```
