### PR TITLE
use safe loaders and dumpers in yaml lib

### DIFF
--- a/jupyter_events/yaml.py
+++ b/jupyter_events/yaml.py
@@ -5,18 +5,18 @@ from yaml import dump as ydump
 from yaml import load as yload
 
 try:
-    from yaml import CDumper as Dumper
-    from yaml import CLoader as Loader
+    from yaml import CSafeDumper as SafeDumper
+    from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import Dumper, Loader
+    from yaml import SafeDumper, SafeLoader
 
 
 def loads(stream):
-    return yload(stream, Loader=Loader)
+    return yload(stream, Loader=SafeLoader)
 
 
 def dumps(stream):
-    return ydump(stream, Dumper=Dumper)
+    return ydump(stream, Dumper=SafeDumper)
 
 
 def load(fpath):


### PR DESCRIPTION
See #26.

`safe_load(stream)` is really just invoking `load(stream, Loader=SafeLoader)`, and similarly for `safe_dump(stream)` ([see source](https://github.com/yaml/pyyaml/blob/8cdff2c80573b8be8e8ad28929264a913a63aa33/lib/yaml/__init__.py#L117)). I've preserved the existing behavior of trying to use the (much faster) C implementation before the Python implementation.

