### PR TITLE
specify utf-8 encoding for loading/dumping yaml

### DIFF
--- a/jupyter_events/yaml.py
+++ b/jupyter_events/yaml.py
@@ -21,9 +21,9 @@ def dumps(stream):
 
 def load(fpath):
     # coerce PurePath into Path, then read its contents
-    data = Path(str(fpath)).read_text()
+    data = Path(str(fpath)).read_text(encoding="utf-8")
     return loads(data)
 
 
 def dump(data, outpath):
-    Path(outpath).write_text(dumps(data))
+    Path(outpath).write_text(dumps(data), encoding="utf-8")


### PR DESCRIPTION
## References
- finishes up findings from #26

## Changes
- adds `encoding="utf-8"` to yaml file operations to avoid broken-by-default default encodings on some platforms/configurations