### PR TITLE
Add CLI tests, return codes, version

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |
-          args="-vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered --cov-report xml"
+          args="-vv --cov jupyter_events --cov-branch --cov-report term-missing:skip-covered --cov-report xml"
           python -m pytest $args --cov-fail-under 88 || python -m pytest $args --lf
       - name: Run the tests on pypy and windows
         if: ${{ startsWith(matrix.python-version, 'pypy') || startsWith(matrix.os, 'windows') }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -122,6 +122,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
         with:
+          package_spec: '--editable ."[test,cli]"'
           test_command: pytest -vv || pytest -vv --lf
 
   python_tests_check: # This job does nothing and is only used for the branch protection

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |
-          args="-vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered"
-          python -m pytest $args  --cov-fail-under 88 || python -m pytest $args --lf
+          args="-vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered --cov-report xml"
+          python -m pytest $args --cov-fail-under 88 || python -m pytest $args --lf
       - name: Run the tests on pypy and windows
         if: ${{ startsWith(matrix.python-version, 'pypy') || startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |
           args="-vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered"
-          python -m pytest $args  --cov-fail-under 90 || python -m pytest $args --lf
+          python -m pytest $args  --cov-fail-under 88 || python -m pytest $args --lf
       - name: Run the tests on pypy and windows
         if: ${{ startsWith(matrix.python-version, 'pypy') || startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |
           args="-vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered"
-          python -m pytest $args  --cov-fail-under 70 || python -m pytest $args --lf
+          python -m pytest $args  --cov-fail-under 90 || python -m pytest $args --lf
       - name: Run the tests on pypy and windows
         if: ${{ startsWith(matrix.python-version, 'pypy') || startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -29,7 +29,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install the Python dependencies
         run: |
-          pip install -e ".[test,cli]" codecov
+          pip install -e ".[test]" codecov
       - name: List and check the Python dependencies
         run: |
           pip list
@@ -122,7 +122,6 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
         with:
-          package_spec: '--editable ."[test,cli]"'
           test_command: pytest -vv || pytest -vv --lf
 
   python_tests_check: # This job does nothing and is only used for the branch protection

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -29,8 +29,11 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install the Python dependencies
         run: |
-          pip install -e ".[test]" codecov
+          pip install -e ".[test,cli]" codecov
+      - name: List and check the Python dependencies
+        run: |
           pip list
+          pip check
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |

--- a/docs/user_guide/defining-schema.md
+++ b/docs/user_guide/defining-schema.md
@@ -57,7 +57,7 @@ pip install "jupyter_events[cli]"
 Then, run the CLI against your schema:
 
 ```
-jupyter events validate path/to/my_schema.json
+jupyter-events validate path/to/my_schema.json
 ```
 
 The output will look like this, if it passes:

--- a/jupyter_events/__init__.py
+++ b/jupyter_events/__init__.py
@@ -1,3 +1,6 @@
 # flake8: noqa
+from ._version import __version__
 from .logger import EVENTS_METADATA_VERSION, EventLogger
 from .schema import EventSchema
+
+__all__ = ["__version__", "EVENTS_METADATA_VERSION, EventLogger", "EventSchema"]

--- a/jupyter_events/cli.py
+++ b/jupyter_events/cli.py
@@ -19,6 +19,7 @@ console = Console()
 
 
 @click.group()
+@click.version_option()
 def main():
     """A simple CLI tool to quickly validate JSON schemas against
     Jupyter Event's custom validator.

--- a/jupyter_events/cli.py
+++ b/jupyter_events/cli.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import platform
 
 import click
 from jsonschema import ValidationError
@@ -15,8 +16,7 @@ from jupyter_events.schema import (
     EventSchemaLoadingError,
 )
 
-console = Console()
-error_console = Console(stderr=True)
+WIN = platform.system() == "Windows"
 
 
 class RC:
@@ -24,6 +24,15 @@ class RC:
     INVALID = 1
     UNPARSEABLE = 2
     NOT_FOUND = 3
+
+
+class EMOJI:
+    X = "XX" if WIN else "\u274c"
+    OK = "OK" if WIN else "\u2714"
+
+
+console = Console()
+error_console = Console(stderr=True)
 
 
 @click.group()
@@ -77,14 +86,14 @@ def validate(ctx: click.Context, schema: str):
         EventSchema(_schema)
         console.rule("Results", style=Style(color="green"))
         out = Padding(
-            "[green]\u2714[white] Nice work! This schema is valid.", (1, 0, 1, 0)
+            f"[green]{EMOJI.OK}[white] Nice work! This schema is valid.", (1, 0, 1, 0)
         )
         console.print(out)
         return ctx.exit(RC.OK)
     except ValidationError as err:
         error_console.rule("Results", style=Style(color="red"))
-        error_console.print("[red]\u274c [white]The schema failed to validate.\n")
-        error_console.print("We found the following error with your schema:")
+        error_console.print(f"[red]{EMOJI.X} [white]The schema failed to validate.")
+        error_console.print("\nWe found the following error with your schema:")
         out = escape(str(err))
         error_console.print(Padding(out, (1, 0, 1, 4)))
         return ctx.exit(RC.INVALID)

--- a/jupyter_events/yaml.py
+++ b/jupyter_events/yaml.py
@@ -7,7 +7,7 @@ from yaml import load as yload
 try:
     from yaml import CSafeDumper as SafeDumper
     from yaml import CSafeLoader as SafeLoader
-except ImportError:
+except ImportError:  # pragma: no cover
     from yaml import SafeDumper, SafeLoader
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ jupyter-events = "jupyter_events.cli:main"
 test = [
     "coverage",
     "pre-commit",
+    "pytest-asyncio",
+    "pytest-console-scripts",
     "pytest-cov",
     "pytest>=6.0",
 ]
@@ -94,3 +96,5 @@ addopts = "-raXs --durations 10 --color=yes --doctest-modules"
 testpaths = [
     "tests/"
 ]
+asyncio_mode = "auto"
+script_launch_mode = "subprocess"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
     "pytest-asyncio>=0.19.0",
     "pytest-console-scripts",
     "pytest-cov",
-    "pytest>=6.0",
+    "pytest>=6.1.0",
     "rich",
 ]
 cli = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,14 @@ jupyter-events = "jupyter_events.cli:main"
 
 [project.optional-dependencies]
 test = [
+    "click",
     "coverage",
     "pre-commit",
     "pytest-asyncio",
     "pytest-console-scripts",
     "pytest-cov",
     "pytest>=6.0",
+    "rich",
 ]
 cli = [
     "click",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ test = [
     "click",
     "coverage",
     "pre-commit",
-    "pytest-asyncio",
+    "pytest-asyncio>=0.19.0",
     "pytest-console-scripts",
     "pytest-cov",
     "pytest>=6.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ VALIDATE = NAME, "validate"
 def test_cli_version(script_runner):
     ret = script_runner.run(NAME, "--version")
     assert ret.success
-    assert ret.stdout.strip() == f"f{NAME}, version {jupyter_events.__version__}"
+    assert ret.stdout.strip() == f"{NAME}, version {jupyter_events.__version__}"
 
 
 def test_cli_help(script_runner):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import pytest
+
 import jupyter_events
 from jupyter_events.cli import RC
 
@@ -7,42 +9,50 @@ NAME = "jupyter-events"
 VALIDATE = NAME, "validate"
 
 
-def test_cli_version(script_runner):
-    ret = script_runner.run(NAME, "--version")
+@pytest.fixture
+def cli(script_runner):
+    def run_cli(*args, **kwargs):
+        return script_runner.run(NAME, *map(str, args), **kwargs)
+
+    return run_cli
+
+
+def test_cli_version(cli):
+    ret = cli("--version")
     assert ret.success
     assert ret.stdout.strip() == f"{NAME}, version {jupyter_events.__version__}"
 
 
-def test_cli_help(script_runner):
-    ret = script_runner.run(NAME, "--help")
+def test_cli_help(cli):
+    ret = cli("--help")
     assert ret.success
     assert f"Usage: {NAME}" in ret.stdout.strip()
 
 
-def test_cli_good(script_runner):
+def test_cli_good(cli):
     """jupyter events validate path/to/my_schema.json"""
-    ret = script_runner.run(*VALIDATE, SCHEMA_PATH / "good/array.yaml")
+    ret = cli("validate", SCHEMA_PATH / "good/array.yaml")
     assert ret.success
     assert not ret.stderr.strip()
     assert "This schema is valid" in ret.stdout
 
 
-def test_cli_missing(script_runner):
-    ret = script_runner.run(*VALIDATE, SCHEMA_PATH / "bad/doesnt-exist.yaml")
+def test_cli_missing(cli):
+    ret = cli("validate", SCHEMA_PATH / "bad/doesnt-exist.yaml")
     assert not ret.success
     assert ret.returncode == RC.UNPARSEABLE
     assert "Schema file not present" in ret.stderr.strip()
 
 
-def test_cli_malformed(script_runner):
-    ret = script_runner.run(*VALIDATE, SCHEMA_PATH / "bad/invalid.yaml")
+def test_cli_malformed(cli):
+    ret = cli("validate", SCHEMA_PATH / "bad/invalid.yaml")
     assert not ret.success
     assert ret.returncode == RC.UNPARSEABLE
     assert "Could not deserialize" in ret.stderr.strip()
 
 
-def test_cli_invalid(script_runner):
-    ret = script_runner.run(*VALIDATE, SCHEMA_PATH / "bad/reserved-property.yaml")
+def test_cli_invalid(cli):
+    ret = cli("validate", SCHEMA_PATH / "bad/reserved-property.yaml")
     assert not ret.success
     assert ret.returncode == RC.INVALID
     assert "The schema failed to validate" in ret.stderr.strip()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,14 @@ def test_cli_good(cli):
     assert "This schema is valid" in ret.stdout
 
 
+def test_cli_good_raw(cli):
+    """jupyter events validate path/to/my_schema.json"""
+    ret = cli("validate", (SCHEMA_PATH / "good/array.yaml").read_text(encoding="utf-8"))
+    assert ret.success
+    assert not ret.stderr.strip()
+    assert "This schema is valid" in ret.stdout
+
+
 def test_cli_missing(cli):
     ret = cli("validate", SCHEMA_PATH / "bad/doesnt-exist.yaml")
     assert not ret.success

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import jupyter_events
@@ -12,6 +14,10 @@ VALIDATE = NAME, "validate"
 @pytest.fixture
 def cli(script_runner):
     def run_cli(*args, **kwargs):
+        env = dict(os.environ)
+        env.update(kwargs.pop("env", {}))
+        env["PYTHONIOENCODING"] = "utf-8"
+        kwargs["env"] = env
         return script_runner.run(NAME, *map(str, args), **kwargs)
 
     return run_cli

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,6 @@
+import jupyter_events
+
+def test_cli_version(script_runner):
+    ret = script_runner.run('jupyter-events', '--version')
+    assert ret.success
+    assert ret.stdout.strip() == f"jupyter-events, version {jupyter_events.__version__}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,19 +3,20 @@ from jupyter_events.cli import RC
 
 from .utils import SCHEMA_PATH
 
-VALIDATE = "jupyter", "events", "validate"
+NAME = "jupyter-events"
+VALIDATE = NAME, "validate"
 
 
 def test_cli_version(script_runner):
-    ret = script_runner.run("jupyter", "events", "--version")
+    ret = script_runner.run(NAME, "--version")
     assert ret.success
-    assert ret.stdout.strip() == f"jupyter-events, version {jupyter_events.__version__}"
+    assert ret.stdout.strip() == f"f{NAME}, version {jupyter_events.__version__}"
 
 
 def test_cli_help(script_runner):
-    ret = script_runner.run("jupyter", "events", "--help")
+    ret = script_runner.run(NAME, "--help")
     assert ret.success
-    assert "Usage: jupyter-events" in ret.stdout.strip()
+    assert f"Usage: {NAME}" in ret.stdout.strip()
 
 
 def test_cli_good(script_runner):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,47 @@
 import jupyter_events
+from jupyter_events.cli import RC
+
+from .utils import SCHEMA_PATH
+
+VALIDATE = "jupyter", "events", "validate"
+
 
 def test_cli_version(script_runner):
-    ret = script_runner.run('jupyter-events', '--version')
+    ret = script_runner.run("jupyter", "events", "--version")
     assert ret.success
     assert ret.stdout.strip() == f"jupyter-events, version {jupyter_events.__version__}"
+
+
+def test_cli_help(script_runner):
+    ret = script_runner.run("jupyter", "events", "--help")
+    assert ret.success
+    assert "Usage: jupyter-events" in ret.stdout.strip()
+
+
+def test_cli_good(script_runner):
+    """jupyter events validate path/to/my_schema.json"""
+    ret = script_runner.run(*VALIDATE, SCHEMA_PATH / "good/array.yaml")
+    assert ret.success
+    assert not ret.stderr.strip()
+    assert "This schema is valid" in ret.stdout
+
+
+def test_cli_missing(script_runner):
+    ret = script_runner.run(*VALIDATE, SCHEMA_PATH / "bad/doesnt-exist.yaml")
+    assert not ret.success
+    assert ret.returncode == RC.UNPARSEABLE
+    assert "Schema file not present" in ret.stderr.strip()
+
+
+def test_cli_malformed(script_runner):
+    ret = script_runner.run(*VALIDATE, SCHEMA_PATH / "bad/invalid.yaml")
+    assert not ret.success
+    assert ret.returncode == RC.UNPARSEABLE
+    assert "Could not deserialize" in ret.stderr.strip()
+
+
+def test_cli_invalid(script_runner):
+    ret = script_runner.run(*VALIDATE, SCHEMA_PATH / "bad/reserved-property.yaml")
+    assert not ret.success
+    assert ret.returncode == RC.INVALID
+    assert "The schema failed to validate" in ret.stderr.strip()


### PR DESCRIPTION
## Changes
- [x] adds `--version` to top-level
- [x] import and hoists `__version__` to `__all__` 
- [x] returns non-zero error codes on failure
- [x] prints errors to stderr
- [x] adds `pytest-console-scripts` (and `pytest-asyncio`) configuration
  - [x] with some minimum versions, also `pytest >=6.1` 
- [x] don't try to use emoji on windows
- [x] tests the cli
- [x] fixes coverage uploading https://app.codecov.io/gh/jupyter/jupyter_events/pull/30 