### PR TITLE
add jsonschema[format-nongpl], core event schema

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -79,6 +79,9 @@ jobs:
           python_version: "3.7"
       - name: Install miniumum versions
         uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
+      - name: Ensure jsonschema[format-nongpl,format_nongpl]
+        run: |
+          pip install jsonschema[format-nongpl,format_nongpl]
       - name: List installed packages
         run: |
           pip freeze

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -79,6 +79,13 @@ jobs:
           python_version: "3.7"
       - name: Install miniumum versions
         uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
+      - name: Ensure jsonschema[format-nongpl]
+        run: |
+          pip install jsonschema[format-nongpl]
+      - name: List installed packages
+        run: |
+          pip freeze
+          pip check
       - name: Run the unit tests
         run: |
           pytest -vv -W default || pytest -vv -W default --lf

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -79,9 +79,6 @@ jobs:
           python_version: "3.7"
       - name: Install miniumum versions
         uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
-      - name: Ensure jsonschema[format-nongpl]
-        run: |
-          pip install jsonschema[format-nongpl]
       - name: List installed packages
         run: |
           pip freeze

--- a/docs/demo/demo-notebook.ipynb
+++ b/docs/demo/demo-notebook.ipynb
@@ -69,7 +69,7 @@
    ],
    "source": [
     "schema = \"\"\"\n",
-    "$id: myapplication.org/example-event\n",
+    "$id: http://myapplication.org/example-event\n",
     "version: 1\n",
     "title: Example Event\n",
     "description: An interesting event to collect\n",

--- a/docs/user_guide/application.md
+++ b/docs/user_guide/application.md
@@ -22,7 +22,7 @@ Register an event schema with the logger.
 
 ```python
         schema = """
-        $id: myapplication.org/my-method
+        $id: http://myapplication.org/my-method
         version: 1
         title: My Method Executed
         description: My method was executed one time.

--- a/docs/user_guide/defining-schema.md
+++ b/docs/user_guide/defining-schema.md
@@ -26,7 +26,7 @@ At a minimum, a valid Jupyter event schema requires the following keys:
 Beyond these required items, any valid JSON should be possible. Here is a simple example of a valid JSON schema for an event.
 
 ```yaml
-$id: event.jupyter.org/example-event
+$id: https://event.jupyter.org/example-event
 version: 1
 title: My Event
 description: |

--- a/docs/user_guide/event-schemas.md
+++ b/docs/user_guide/event-schemas.md
@@ -12,7 +12,7 @@ _So what exactly happens when we register a schema?_
 from jupyter_events.logger import EventLogger
 
 schema = """
-$id: myapplication.org/example-event
+$id: http://myapplication.org/example-event
 version: 1
 title: Example Event
 description: An interesting event to collect

--- a/docs/user_guide/first-event.md
+++ b/docs/user_guide/first-event.md
@@ -14,7 +14,7 @@ To begin emitting events from a Python application, you need to tell the `EventL
 
 ```python
 schema = """
-$id: myapplication.org/example-event
+$id: http://myapplication.org/example-event
 version: 1
 title: Example Event
 description: An interesting event to collect
@@ -45,7 +45,7 @@ The logger knows about the event and where to send it; all that's left is to emi
 from jupyter_events import Event
 
 logger.emit(
-      schema_id="myapplication.org/example-event",
+      schema_id="http://myapplication.org/example-event",
       data={
          "name": "My Event"
       }

--- a/jupyter_events/__init__.py
+++ b/jupyter_events/__init__.py
@@ -3,4 +3,4 @@ from ._version import __version__
 from .logger import EVENTS_METADATA_VERSION, EventLogger
 from .schema import EventSchema
 
-__all__ = ["__version__", "EVENTS_METADATA_VERSION, EventLogger", "EventSchema"]
+__all__ = ["__version__", "EVENTS_METADATA_VERSION", "EventLogger", "EventSchema"]

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -6,7 +6,7 @@ from jsonschema import FormatChecker, validators
 from jsonschema.protocols import Validator
 
 from . import yaml
-from .validators import validate_schema
+from .validators import draft7_format_checker, validate_schema
 
 
 class EventSchemaUnrecognized(Exception):
@@ -47,7 +47,7 @@ class EventSchema:
         self,
         schema: Union[dict, str, PurePath],
         validator_class: Validator = validators.Draft7Validator,
-        format_checker: FormatChecker = validators.Draft7Validator.FORMAT_CHECKER,
+        format_checker: FormatChecker = draft7_format_checker,
         resolver=None,
     ):
         _schema = self._load_schema(schema)

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path, PurePath
 from typing import Union
 
-from jsonschema import validators
+from jsonschema import FormatChecker, validators
 from jsonschema.protocols import Validator
 
 from . import yaml
@@ -47,13 +47,16 @@ class EventSchema:
         self,
         schema: Union[dict, str, PurePath],
         validator_class: Validator = validators.Draft7Validator,
+        format_checker: FormatChecker = validators.Draft7Validator.FORMAT_CHECKER,
         resolver=None,
     ):
         _schema = self._load_schema(schema)
         # Validate the schema against Jupyter Events metaschema.
         validate_schema(_schema)
         # Create a validator for this schema
-        self._validator = validator_class(_schema, resolver=resolver)
+        self._validator = validator_class(
+            _schema, resolver=resolver, format_checker=format_checker
+        )
         self._schema = _schema
 
     def __repr__(self):

--- a/jupyter_events/schemas/event-core-schema.yml
+++ b/jupyter_events/schemas/event-core-schema.yml
@@ -1,0 +1,27 @@
+$schema: http://json-schema.org/draft-07/schema
+$id: http://event.jupyter.org/event-schema
+version: 1
+title: Event Schema
+description: |
+  A schema for validating any Jupyter Event.
+type: object
+properties:
+  __metadata_version__:
+    title: Metadata Version
+    type: number
+    const: 1
+  __schema_version__:
+    title: Schema Version
+    type: integer
+  __schema__:
+    title: Schema ID
+    type: string
+  __timestamp__:
+    title: Event Timestamp
+    type: string
+    format: datetime
+required:
+  - __metadata_version__
+  - __schema__
+  - __schema_version__
+  - __timestamp__

--- a/jupyter_events/schemas/event-metaschema.yml
+++ b/jupyter_events/schemas/event-metaschema.yml
@@ -19,6 +19,11 @@ properties:
       $ref: http://event.jupyter.org/property-metaschema
     propertyNames:
       pattern: ^(?!__.*)
+patternProperties:
+  "\\$id":
+    type: string
+    format: uri
+
 
 required:
   - $id

--- a/jupyter_events/schemas/event-metaschema.yml
+++ b/jupyter_events/schemas/event-metaschema.yml
@@ -24,7 +24,6 @@ patternProperties:
     type: string
     format: uri
 
-
 required:
   - $id
   - version

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -1,6 +1,13 @@
 import pathlib
 
+import jsonschema
 from jsonschema import Draft7Validator, RefResolver, ValidationError
+
+draft7_format_checker = (
+    Draft7Validator.FORMAT_CHECKER
+    if hasattr(Draft7Validator, "FORMAT_CHECKER")
+    else jsonschema.draft7_format_checker
+)
 
 from . import yaml
 
@@ -28,13 +35,13 @@ METASCHEMA_RESOLVER = RefResolver(
 JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(
     schema=EVENT_METASCHEMA,
     resolver=METASCHEMA_RESOLVER,
-    format_checker=Draft7Validator.FORMAT_CHECKER,
+    format_checker=draft7_format_checker,
 )
 
 JUPYTER_EVENTS_CORE_VALIDATOR = Draft7Validator(
     schema=EVENT_CORE_SCHEMA,
     resolver=METASCHEMA_RESOLVER,
-    format_checker=Draft7Validator.FORMAT_CHECKER,
+    format_checker=draft7_format_checker,
 )
 
 

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -1,29 +1,47 @@
 import pathlib
 
-from jsonschema import RefResolver, ValidationError, validators
+from jsonschema import Draft7Validator, RefResolver, ValidationError
 
 from . import yaml
 
 METASCHEMA_PATH = pathlib.Path(__file__).parent.joinpath("schemas")
+
 EVENT_METASCHEMA_FILEPATH = METASCHEMA_PATH.joinpath("event-metaschema.yml")
 EVENT_METASCHEMA = yaml.load(EVENT_METASCHEMA_FILEPATH)
+
+EVENT_CORE_SCHEMA_FILEPATH = METASCHEMA_PATH.joinpath("event-core-schema.yml")
+EVENT_CORE_SCHEMA = yaml.load(EVENT_CORE_SCHEMA_FILEPATH)
+
 PROPERTY_METASCHEMA_FILEPATH = METASCHEMA_PATH.joinpath("property-metaschema.yml")
 PROPERTY_METASCHEMA = yaml.load(PROPERTY_METASCHEMA_FILEPATH)
+
 SCHEMA_STORE = {
+    EVENT_METASCHEMA["$id"]: EVENT_METASCHEMA,
     PROPERTY_METASCHEMA["$id"]: PROPERTY_METASCHEMA,
+    EVENT_CORE_SCHEMA["$id"]: EVENT_CORE_SCHEMA,
 }
+
 METASCHEMA_RESOLVER = RefResolver(
     base_uri=EVENT_METASCHEMA["$id"], referrer=EVENT_METASCHEMA, store=SCHEMA_STORE
 )
-JUPYTER_EVENTS_VALIDATOR = validators.Draft202012Validator(
-    schema=EVENT_METASCHEMA, resolver=METASCHEMA_RESOLVER
+
+JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(
+    schema=EVENT_METASCHEMA,
+    resolver=METASCHEMA_RESOLVER,
+    format_checker=Draft7Validator.FORMAT_CHECKER,
+)
+
+JUPYTER_EVENTS_CORE_VALIDATOR = Draft7Validator(
+    schema=EVENT_CORE_SCHEMA,
+    resolver=METASCHEMA_RESOLVER,
+    format_checker=Draft7Validator.FORMAT_CHECKER,
 )
 
 
 def validate_schema(schema: dict):
     try:
         # Validate the schema against Jupyter Events metaschema.
-        JUPYTER_EVENTS_VALIDATOR.validate(schema)
+        JUPYTER_EVENTS_SCHEMA_VALIDATOR.validate(schema)
     except ValidationError as err:
         reserved_property_msg = " does not match '^(?!__.*)'"
         if reserved_property_msg in str(err):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,16 @@ jupyter-events = "jupyter_events.cli:main"
 
 [project.optional-dependencies]
 test = [
-    "click",
     "coverage",
     "pre-commit",
     "pytest-asyncio>=0.19.0",
     "pytest-console-scripts",
     "pytest-cov",
     "pytest>=6.1.0",
+    # dependencies, again, for minimum version test
+    "jsonschema[format-nongpl]",
+    # [cli]
+    "click",
     "rich",
 ]
 cli = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "jsonschema[format-nongpl]>=4.3.0",
+    "jsonschema[format-nongpl]>=4.5.0",
     "python-json-logger",
     "pyyaml",
     "traitlets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "jsonschema[format-nongpl]>=4.3.0",
+    "jsonschema[format-nongpl,format_nongpl]>=4.3.0",
     "python-json-logger",
     "pyyaml",
     "traitlets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,6 @@ test = [
     "pytest-console-scripts",
     "pytest-cov",
     "pytest>=6.1.0",
-    # dependencies, again, for minimum version test
-    "jsonschema[format-nongpl]",
     # [cli]
     "click",
     "rich",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "jsonschema[format-nongpl]>=4.5.0",
+    "jsonschema[format-nongpl]>=4.3.0",
     "python-json-logger",
     "pyyaml",
     "traitlets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "jsonschema[formats-nongpl]>=4.3.0",
+    "jsonschema[format-nongpl]>=4.3.0",
     "python-json-logger",
     "pyyaml",
     "traitlets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "jsonschema>=4.3.0",
+    "jsonschema[formats-nongpl]>=4.3.0",
     "python-json-logger",
     "pyyaml",
     "traitlets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ cli = [
 [tool.hatch.version]
 path = "jupyter_events/_version.py"
 
+[tool.isort]
+profile = "black"
+
 [tool.tbump.version]
 current = "0.5.0.dev0"
 regex = '''

--- a/tests/schemas/bad/bad-id.yaml
+++ b/tests/schemas/bad/bad-id.yaml
@@ -1,0 +1,11 @@
+$id: not-a-uri
+version: 1
+title: Schema with a Bad URI ID
+description: |
+  A schema with a bad id
+type: object
+properties:
+  bad:
+    title: Test Property
+    description: Test property.
+    type: string

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -241,7 +241,7 @@ def test_emit_badschema():
             schema_id="http://test/test", data={"something": "blah", "status": "hi"}
         )
 
-    assert "not-in-enum" in str(excinfo.value)
+    assert "'hi' is not one of" in str(excinfo.value)
 
 
 def test_emit_badschema_format():
@@ -264,35 +264,6 @@ def test_emit_badschema_format():
         el.emit(schema_id="http://test/test", data={"something": "chucknorris"})
 
     assert "'chucknorris' is not a 'date-time'" in str(excinfo.value)
-
-
-def test_emit_badschema():
-    """
-    Fail fast when an event doesn't conform to its schema
-    """
-    schema = {
-        "$id": "http://test/test",
-        "version": 1,
-        "type": "object",
-        "properties": {
-            "something": {
-                "type": "string",
-                "title": "test",
-            },
-            "status": {
-                "enum": ["success", "failure"],
-                "title": "test 2",
-            },
-        },
-    }
-
-    el = EventLogger(handlers=[logging.NullHandler()])
-    el.register_event_schema(schema)
-
-    with pytest.raises(jsonschema.ValidationError):
-        el.emit(
-            schema_id="http://test/test", data={"something": "blah", "status": "hi"}
-        )  # 'not-in-enum'
 
 
 def test_unique_logger_instances():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,6 +18,7 @@ from .utils import SCHEMA_PATH
 BAD_SCHEMAS = [
     ["reserved-property.yaml", "Properties starting with 'dunder'"],
     ["nested-reserved-property.yaml", "Properties starting with 'dunder'"],
+    ["bad-id.yaml", "'not-a-uri' is not a 'uri'"],
 ]
 
 GOOD_SCHEMAS = ["array.yaml", "nested-array.yaml", "basic.yaml"]


### PR DESCRIPTION
## References
- fixes #27

## Changes
- [x] fixes bad `__all__` from #30
- [x] add `jsonschema[formats-nongpl]`
- [x] adds a `event-core-schema.yml` for `__` fields
- [x] add some tests of `date-time` format 
- [x] remove references to undefined `allowed_schemas` 

## Dubious changes
> could roll these back

- [x] enforces event schema `$id` as URI
  - not strictly _required_ per the JSON schema spec, but in practice pretty useful to rely on
- [x] validate `__` metadata fields with core schema in logger 
  - as these are strictly generated immediately above, there's really no reason to keep it