### PR TITLE
Clean up pyproject and ci

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -131,6 +131,14 @@ jobs:
         with:
           test_command: pytest -vv || pytest -vv --lf
 
+  check_links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+
   python_tests_check: # This job does nothing and is only used for the branch protection
     if: always()
     needs:
@@ -139,6 +147,7 @@ jobs:
       - test_prereleases
       - make_sdist
       - test_sdist
+      - check-links
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -147,7 +147,7 @@ jobs:
       - test_prereleases
       - make_sdist
       - test_sdist
-      - check-links
+      - check_links
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/jupyter_events/_version.py
+++ b/jupyter_events/_version.py
@@ -1,2 +1,20 @@
-version_info = (0, 6, 0, ".dev", "0")
+"""
+store the current version info of jupyter-events.
+"""
+import re
+from typing import List
+
+# Version string must appear intact for hatch versioning
 __version__ = "0.6.0.dev0"
+
+# Build up version_info tuple for backwards compatibility
+pattern = r"(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)"
+match = re.match(pattern, __version__)
+assert match is not None
+parts: List[object] = [int(match[part]) for part in ["major", "minor", "patch"]]
+if match["rest"]:
+    parts.append(match["rest"])
+version_info = tuple(parts)
+
+kernel_protocol_version_info = (5, 3)
+kernel_protocol_version = "%s.%s" % kernel_protocol_version_info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,5 @@
 [build-system]
-requires = [
-    "hatchling>=1.3.0",
-]
+requires = ["hatchling>=1.5"]
 build-backend = "hatchling.build"
 
 [project]
@@ -63,39 +61,11 @@ cli = [
 [tool.hatch.version]
 path = "jupyter_events/_version.py"
 
+[tool.jupyter-releaser]
+skip = ["check-links"]
+
 [tool.isort]
 profile = "black"
-
-[tool.tbump.version]
-current = "0.6.0.dev0"
-regex = '''
-  (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-  ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
-'''
-
-[tool.tbump.git]
-message_template = "Bump to {new_version}"
-tag_template = "v{new_version}"
-
-[[tool.tbump.file]]
-src = "jupyter_events/_version.py"
-version_template = '({major}, {minor}, {patch}, "{channel}", "{release}")'
-
-[[tool.tbump.file]]
-src = "jupyter_events/_version.py"
-version_template = "{major}.{minor}.{patch}{channel}{release}"
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-version_template = "{major}.{minor}.{patch}{channel}{release}"
-
-[[tool.tbump.field]]
-name = "channel"
-default = ""
-
-[[tool.tbump.field]]
-name = "release"
-default = ""
 
 [tool.pytest.ini_options]
 addopts = "-raXs --durations 10 --color=yes --doctest-modules"


### PR DESCRIPTION
- Remove unused tbump config
- Use the new `check-links` action from `maintainer-tools`