### PR TITLE
Fix listener example

### DIFF
--- a/docs/user_guide/listeners.md
+++ b/docs/user_guide/listeners.md
@@ -18,7 +18,7 @@ async def my_listener(logger: EventLogger, schema_id: str, data: dict) -> None:
 Hook this listener to a specific event type:
 
 ```python
-event_logger.add_listener("http://event.jupyter.org/my-event", listener=my_listener)
+event_logger.add_listener(schema_id="http://event.jupyter.org/my-event", listener=my_listener)
 ```
 
 Now, every time a `"http://event.jupyter.org/test"` event is emitted from the EventLogger, this listener will be called.


### PR DESCRIPTION
`EventLogger#add_listener()` actually doesn't take any positional arguments excluding `self`, but the example states otherwise. This corrects the docs to match the API.