### PR TITLE
Remove artificial cap on jsonschema dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "jsonschema[format-nongpl,format_nongpl]>=3.2.0,<4",
+    "jsonschema[format-nongpl,format_nongpl]>=3.2.0",
     "python-json-logger>=2.0.4",
     "pyyaml>=6.0",
     "traitlets>=5.3",


### PR DESCRIPTION
While working on #59, a cap `<4` was added to the `jsonschema` dependency to simulate behaviors of other repositories that have capped `jsonschema<4`.  It was intended to be removed prior to its merge, but that got lost in the shuffle.  This pull request removes that artificial cap.