### PR TITLE
allow a 'message' field in an event schema

### DIFF
--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -144,6 +144,10 @@ class EventSchema:
         """Schema's version."""
         return self._schema["version"]
 
+    @property
+    def properties(self) -> dict:
+        return self._schema["properties"]
+
     def validate(self, data: dict) -> None:
         """Validate an incoming instance of this event schema."""
         self._validator.validate(data)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -136,7 +136,7 @@ def test_emit():
             "something": {
                 "type": "string",
                 "title": "test",
-            },
+            }
         },
     }
 
@@ -163,6 +163,51 @@ def test_emit():
         "__schema_version__": 1,
         "__metadata_version__": 1,
         "something": "blah",
+    }
+
+
+def test_message_field():
+    """
+    Simple test for emitting an event with
+    the literal property "message".
+    """
+    schema = {
+        "$id": "http://test/test",
+        "version": 1,
+        "properties": {
+            "something": {
+                "type": "string",
+                "title": "test",
+            },
+            "message": {
+                "type": "string",
+                "title": "test",
+            },
+        },
+    }
+
+    output = io.StringIO()
+    handler = logging.StreamHandler(output)
+    el = EventLogger(handlers=[handler])
+    el.register_event_schema(schema)
+
+    el.emit(
+        schema_id="http://test/test",
+        data={"something": "blah", "message": "a message was seen"},
+    )
+    handler.flush()
+
+    event_capsule = json.loads(output.getvalue())
+
+    assert "__timestamp__" in event_capsule
+    # Remove timestamp from capsule when checking equality, since it is gonna vary
+    del event_capsule["__timestamp__"]
+    assert event_capsule == {
+        "__schema__": "http://test/test",
+        "__schema_version__": 1,
+        "__metadata_version__": 1,
+        "something": "blah",
+        "message": "a message was seen",
     }
 
 


### PR DESCRIPTION
jupyter_events implicitly doesn't allow "message" to be a property of an event schema. Because "message" is a common enough field name for events, this PR special-cases this key and allows it to be used in event schemas. 

The issue was that Python's logging library uses the "message" field for other purposes. In the early days of jupyter_events, "message" caused issues for us, because the native `Logger` objects _always_ wanted to emit the "message" field, even if it wasn't in the event schema. As a simple fix, we stripped "message" from the event data and made "message" a disallowed field in jupyter_events. That said, we made things confusing by not explicitly invalidating schemas that included "message" in the schema; rather, we just silently removed this key. 

Either way, we need a fix for this. This PR makes "message" an allowed field, and ensures it's only emitted when it's found in the schema.

See the discussion here for some motivation: https://github.com/jupyter-server/jupyter_server/pull/1252#discussion_r1160785972