### PR TITLE
Improve usability of jp_read_emitted_events fixture

### DIFF
--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -63,7 +63,7 @@ class EventLogger(LoggingConfigurable):
     """
 
     handlers = Handlers(
-        default_value=[],
+        default_value=None,
         allow_none=True,
         help="""A list of logging.Handler instances to send events to.
 

--- a/jupyter_events/pytest_plugin.py
+++ b/jupyter_events/pytest_plugin.py
@@ -26,8 +26,8 @@ def jp_read_emitted_events(jp_event_handler, jp_event_sink):
 
     def _read():
         jp_event_handler.flush()
-        lines = jp_event_sink.getvalue().strip().split("\n")
-        output = [json.loads(item) for item in lines]
+        event_buf = jp_event_sink.getvalue().strip()
+        output = [json.loads(item) for item in event_buf.split("\n")] if event_buf else None
         # Clear the sink.
         jp_event_sink.truncate(0)
         jp_event_sink.seek(0)


### PR DESCRIPTION
Prior to this change, if a test using events attempts to read emitted events using the fixture `jp_read_emitted_events` where either no events were emitted or the handler wasn't registered correctly, a `JSONDecodeError` will be produced, along with its stack trace:
```
tests/test_gateway.py:504: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/miniconda3/envs/server-dev/lib/python3.9/site-packages/jupyter_events/pytest_plugin.py:30: in _read
    output = [json.loads(item) for item in lines]
/opt/miniconda3/envs/server-dev/lib/python3.9/site-packages/jupyter_events/pytest_plugin.py:30: in <listcomp>
    output = [json.loads(item) for item in lines]
/opt/miniconda3/envs/server-dev/lib/python3.9/json/__init__.py:346: in loads
    return _default_decoder.decode(s)
/opt/miniconda3/envs/server-dev/lib/python3.9/json/decoder.py:337: in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <json.decoder.JSONDecoder object at 0x10e8f1e50>, s = '', idx = 0

    def raw_decode(self, s, idx=0):
        """Decode a JSON document from ``s`` (a ``str`` beginning with
        a JSON document) and return a 2-tuple of the Python
        representation and the index in ``s`` where the document ended.
    
        This can be used to decode a JSON document from a string that may
        have extraneous data at the end.
    
        """
        try:
            obj, end = self.scan_once(s, idx)
        except StopIteration as err:
>           raise JSONDecodeError("Expecting value", s, err.value) from None
E           json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

/opt/miniconda3/envs/server-dev/lib/python3.9/json/decoder.py:355: JSONDecodeError
```
This pull request avoids the call to `json.loads()` when the event sink is empty and returns `None`, leading to a more friendly and intuitive error situation:
```
>       output = jp_read_emitted_events()[0]
E       TypeError: 'NoneType' object is not subscriptable

tests/test_gateway.py:504: TypeError
```
----
While looking into this change, I noticed that the default value for the `handlers` trait was set to `[]` despite the help string stating that `None` is the default, so I've gone ahead and changed the default to `None`.