### PR TITLE
Adjust tests for taskName attribute added in Python 3.12

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -163,6 +163,7 @@ def test_emit():
         "__schema_version__": 1,
         "__metadata_version__": 1,
         "something": "blah",
+        "taskName": None,
     }
 
 
@@ -416,6 +417,7 @@ def test_unique_logger_instances():
         "__schema_version__": 1,
         "__metadata_version__": 1,
         "something": "blah",
+        "taskName": None,
     }
 
     event_capsule1 = json.loads(output1.getvalue())
@@ -428,6 +430,7 @@ def test_unique_logger_instances():
         "__schema_version__": 1,
         "__metadata_version__": 1,
         "something": "blah",
+        "taskName": None,
     }
 
 


### PR DESCRIPTION
Added taskName attribute to logging module for use with asyncio tasks. python/cpython#91513

This PR works with Python 3.12 only. 