### PR TITLE
Migrate RefResolver to referencing.Registry

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.12"]
         include:
           - os: windows-latest
             python-version: "3.9"
@@ -27,7 +27,7 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.10"
           - os: macos-latest
-            python-version: "3.8"
+            python-version: "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -4,7 +4,7 @@ from pathlib import Path, PurePath
 from typing import Optional, Type, Union
 
 from jsonschema import FormatChecker, validators
-from referencing import Registry
+from referencing import Registry, Resource
 from referencing.jsonschema import DRAFT7
 
 try:
@@ -74,7 +74,7 @@ class EventSchema:
         validate_schema(_schema)
 
         if registry is None:
-            registry = Registry().with_resource(_schema["$id"], DRAFT7.create_resource(_schema))
+            registry = DRAFT7.create_resource(_schema) @ Registry()
 
         # Create a validator for this schema
         self._validator = validator_class(_schema, registry=registry, format_checker=format_checker)  # type: ignore

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -3,7 +3,8 @@ import json
 from pathlib import Path, PurePath
 from typing import Optional, Type, Union
 
-from jsonschema import FormatChecker, RefResolver, validators
+from jsonschema import FormatChecker, validators
+from referencing import Registry
 
 try:
     from jsonschema.protocols import Validator
@@ -55,8 +56,8 @@ class EventSchema:
         any schema registered here follows the expected form
         of Jupyter Events.
 
-    resolver:
-        RefResolver for nested JSON schema references.
+    registry:
+        Registry for nested JSON schema references.
     """
 
     def __init__(
@@ -64,14 +65,14 @@ class EventSchema:
         schema: SchemaType,
         validator_class: Type[Validator] = validators.Draft7Validator,  # type:ignore[assignment]
         format_checker: FormatChecker = draft7_format_checker,
-        resolver: Optional[RefResolver] = None,
+        registry: Optional[Registry] = None,
     ):
         """Initialize an event schema."""
         _schema = self._load_schema(schema)
         # Validate the schema against Jupyter Events metaschema.
         validate_schema(_schema)
         # Create a validator for this schema
-        self._validator = validator_class(_schema, resolver=resolver, format_checker=format_checker)
+        self._validator = validator_class(_schema, registry=registry, format_checker=format_checker)
         self._schema = _schema
 
     def __repr__(self):

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -5,6 +5,7 @@ from typing import Optional, Type, Union
 
 from jsonschema import FormatChecker, validators
 from referencing import Registry
+from referencing.jsonschema import DRAFT7
 
 try:
     from jsonschema.protocols import Validator
@@ -71,6 +72,10 @@ class EventSchema:
         _schema = self._load_schema(schema)
         # Validate the schema against Jupyter Events metaschema.
         validate_schema(_schema)
+
+        if registry is None:
+            registry = Registry().with_resource(_schema["$id"], DRAFT7.create_resource(_schema))
+
         # Create a validator for this schema
         self._validator = validator_class(_schema, registry=registry, format_checker=format_checker)
         self._schema = _schema

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -77,7 +77,7 @@ class EventSchema:
             registry = Registry().with_resource(_schema["$id"], DRAFT7.create_resource(_schema))
 
         # Create a validator for this schema
-        self._validator = validator_class(_schema, registry=registry, format_checker=format_checker) # type: ignore
+        self._validator = validator_class(_schema, registry=registry, format_checker=format_checker)  # type: ignore
         self._schema = _schema
 
     def __repr__(self):

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -77,7 +77,7 @@ class EventSchema:
             registry = Registry().with_resource(_schema["$id"], DRAFT7.create_resource(_schema))
 
         # Create a validator for this schema
-        self._validator = validator_class(_schema, registry=registry, format_checker=format_checker)
+        self._validator = validator_class(_schema, registry=registry, format_checker=format_checker) # type: ignore
         self._schema = _schema
 
     def __repr__(self):

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -4,7 +4,7 @@ from pathlib import Path, PurePath
 from typing import Optional, Type, Union
 
 from jsonschema import FormatChecker, validators
-from referencing import Registry, Resource
+from referencing import Registry
 from referencing.jsonschema import DRAFT7
 
 try:

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -40,13 +40,13 @@ METASCHEMA_REGISTRY = Registry().with_resources(  # type:ignore
     ]
 )
 
-JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator( # type: ignore
+JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(  # type: ignore
     schema=EVENT_METASCHEMA,
     registry=METASCHEMA_REGISTRY,
     format_checker=draft7_format_checker,
 )
 
-JUPYTER_EVENTS_CORE_VALIDATOR = Draft7Validator( # type: ignore
+JUPYTER_EVENTS_CORE_VALIDATOR = Draft7Validator(  # type: ignore
     schema=EVENT_CORE_SCHEMA,
     registry=METASCHEMA_REGISTRY,
     format_checker=draft7_format_checker,

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -1,4 +1,5 @@
 """Event validators."""
+from __future__ import annotations
 import pathlib
 
 import jsonschema
@@ -36,7 +37,7 @@ resources = [
     DRAFT7.create_resource(each)
     for each in (EVENT_METASCHEMA, PROPERTY_METASCHEMA, EVENT_CORE_SCHEMA)
 ]
-METASCHEMA_REGISTRY = resources @ Registry()
+METASCHEMA_REGISTRY: list = resources @ Registry()
 
 JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(  # type: ignore
     schema=EVENT_METASCHEMA,

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -1,6 +1,4 @@
 """Event validators."""
-from __future__ import annotations
-
 import pathlib
 
 import jsonschema
@@ -38,7 +36,7 @@ resources = [
     DRAFT7.create_resource(each)
     for each in (EVENT_METASCHEMA, PROPERTY_METASCHEMA, EVENT_CORE_SCHEMA)
 ]
-METASCHEMA_REGISTRY: list = resources @ Registry()
+METASCHEMA_REGISTRY: Registry = resources @ Registry()
 
 JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(  # type: ignore
     schema=EVENT_METASCHEMA,

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -32,7 +32,7 @@ SCHEMA_STORE = {
     EVENT_CORE_SCHEMA["$id"]: EVENT_CORE_SCHEMA,
 }
 
-METASCHEMA_REGISTRY = Registry().with_resources(
+METASCHEMA_REGISTRY = Registry().with_resources( # type:ignore
     [
         (EVENT_METASCHEMA["$id"], DRAFT7.create_resource(EVENT_METASCHEMA)),
         (PROPERTY_METASCHEMA["$id"], DRAFT7.create_resource(PROPERTY_METASCHEMA)),

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -1,5 +1,6 @@
 """Event validators."""
 from __future__ import annotations
+
 import pathlib
 
 import jsonschema

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -32,13 +32,8 @@ SCHEMA_STORE = {
     EVENT_CORE_SCHEMA["$id"]: EVENT_CORE_SCHEMA,
 }
 
-METASCHEMA_REGISTRY = Registry().with_resources(  # type:ignore
-    [
-        (EVENT_METASCHEMA["$id"], DRAFT7.create_resource(EVENT_METASCHEMA)),
-        (PROPERTY_METASCHEMA["$id"], DRAFT7.create_resource(PROPERTY_METASCHEMA)),
-        (EVENT_CORE_SCHEMA["$id"], DRAFT7.create_resource(EVENT_CORE_SCHEMA)),
-    ]
-)
+resources = [DRAFT7.create_resource(each) for each in (EVENT_METASCHEMA, PROPERTY_METASCHEMA, EVENT_CORE_SCHEMA)]
+METASCHEMA_REGISTRY = resources @ Registry()
 
 JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(  # type: ignore
     schema=EVENT_METASCHEMA,

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -32,7 +32,10 @@ SCHEMA_STORE = {
     EVENT_CORE_SCHEMA["$id"]: EVENT_CORE_SCHEMA,
 }
 
-resources = [DRAFT7.create_resource(each) for each in (EVENT_METASCHEMA, PROPERTY_METASCHEMA, EVENT_CORE_SCHEMA)]
+resources = [
+    DRAFT7.create_resource(each)
+    for each in (EVENT_METASCHEMA, PROPERTY_METASCHEMA, EVENT_CORE_SCHEMA)
+]
 METASCHEMA_REGISTRY = resources @ Registry()
 
 JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(  # type: ignore

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -40,13 +40,13 @@ METASCHEMA_REGISTRY = Registry().with_resources(  # type:ignore
     ]
 )
 
-JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(
+JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator( # type: ignore
     schema=EVENT_METASCHEMA,
     registry=METASCHEMA_REGISTRY,
     format_checker=draft7_format_checker,
 )
 
-JUPYTER_EVENTS_CORE_VALIDATOR = Draft7Validator(
+JUPYTER_EVENTS_CORE_VALIDATOR = Draft7Validator( # type: ignore
     schema=EVENT_CORE_SCHEMA,
     registry=METASCHEMA_REGISTRY,
     format_checker=draft7_format_checker,

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -2,7 +2,9 @@
 import pathlib
 
 import jsonschema
-from jsonschema import Draft7Validator, RefResolver, ValidationError
+from jsonschema import Draft7Validator, ValidationError
+from referencing import Registry
+from referencing.jsonschema import DRAFT7
 
 from . import yaml
 
@@ -30,19 +32,23 @@ SCHEMA_STORE = {
     EVENT_CORE_SCHEMA["$id"]: EVENT_CORE_SCHEMA,
 }
 
-METASCHEMA_RESOLVER = RefResolver(
-    base_uri=EVENT_METASCHEMA["$id"], referrer=EVENT_METASCHEMA, store=SCHEMA_STORE
+METASCHEMA_REGISTRY = Registry().with_resources(
+    [
+        (EVENT_METASCHEMA["$id"], DRAFT7.create_resource(EVENT_METASCHEMA)),
+        (PROPERTY_METASCHEMA["$id"], DRAFT7.create_resource(PROPERTY_METASCHEMA)),
+        (EVENT_CORE_SCHEMA["$id"], DRAFT7.create_resource(EVENT_CORE_SCHEMA))
+    ]
 )
 
 JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(
     schema=EVENT_METASCHEMA,
-    resolver=METASCHEMA_RESOLVER,
+    registry=METASCHEMA_REGISTRY,
     format_checker=draft7_format_checker,
 )
 
 JUPYTER_EVENTS_CORE_VALIDATOR = Draft7Validator(
     schema=EVENT_CORE_SCHEMA,
-    resolver=METASCHEMA_RESOLVER,
+    registry=METASCHEMA_REGISTRY,
     format_checker=draft7_format_checker,
 )
 

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -32,11 +32,11 @@ SCHEMA_STORE = {
     EVENT_CORE_SCHEMA["$id"]: EVENT_CORE_SCHEMA,
 }
 
-METASCHEMA_REGISTRY = Registry().with_resources( # type:ignore
+METASCHEMA_REGISTRY = Registry().with_resources(  # type:ignore
     [
         (EVENT_METASCHEMA["$id"], DRAFT7.create_resource(EVENT_METASCHEMA)),
         (PROPERTY_METASCHEMA["$id"], DRAFT7.create_resource(PROPERTY_METASCHEMA)),
-        (EVENT_CORE_SCHEMA["$id"], DRAFT7.create_resource(EVENT_CORE_SCHEMA))
+        (EVENT_CORE_SCHEMA["$id"], DRAFT7.create_resource(EVENT_CORE_SCHEMA)),
     ]
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
+    "referencing",
     "jsonschema[format-nongpl,format_nongpl]>=3.2.0",
     "python-json-logger>=2.0.4",
     "pyyaml>=5.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyter-events"
 description = "Jupyter Event System library"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "referencing",
-    "jsonschema[format-nongpl,format_nongpl]>=3.2.0",
+    "jsonschema[format-nongpl,format_nongpl]>=4.18.0",
     "python-json-logger>=2.0.4",
     "pyyaml>=5.3",
     "traitlets>=5.3",

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -158,12 +158,15 @@ def test_emit():
     assert "__timestamp__" in event_capsule
     # Remove timestamp from capsule when checking equality, since it is gonna vary
     del event_capsule["__timestamp__"]
-    assert event_capsule == {
+    expected = {
         "__schema__": "http://test/test",
         "__schema_version__": 1,
         "__metadata_version__": 1,
         "something": "blah",
     }
+    if sys.version_info >= (3, 12):
+        expected["taskName"] = None
+    assert event_capsule == expected
 
 
 def test_message_field():
@@ -411,24 +414,30 @@ def test_unique_logger_instances():
     assert "__timestamp__" in event_capsule0
     # Remove timestamp from capsule when checking equality, since it is gonna vary
     del event_capsule0["__timestamp__"]
-    assert event_capsule0 == {
+    expected = {
         "__schema__": "http://test/test0",
         "__schema_version__": 1,
         "__metadata_version__": 1,
         "something": "blah",
     }
+    if sys.version_info >= (3, 12):
+        expected["taskName"] = None
+    assert event_capsule0 == expected
 
     event_capsule1 = json.loads(output1.getvalue())
 
     assert "__timestamp__" in event_capsule1
     # Remove timestamp from capsule when checking equality, since it is gonna vary
     del event_capsule1["__timestamp__"]
-    assert event_capsule1 == {
+    expected = {
         "__schema__": "http://test/test1",
         "__schema_version__": 1,
         "__metadata_version__": 1,
         "something": "blah",
     }
+    if sys.version_info >= (3, 12):
+        expected["taskName"] = None
+    assert event_capsule1 == expected
 
 
 def test_register_duplicate_schemas():

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -206,13 +206,16 @@ def test_message_field():
     assert "__timestamp__" in event_capsule
     # Remove timestamp from capsule when checking equality, since it is gonna vary
     del event_capsule["__timestamp__"]
-    assert event_capsule == {
+    expected = {
         "__schema__": "http://test/test",
         "__schema_version__": 1,
         "__metadata_version__": 1,
         "something": "blah",
         "message": "a message was seen",
     }
+    if sys.version_info >= (3, 12):
+        expected["taskName"] = None
+    assert event_capsule == expected
 
 
 def test_nested_message_field():
@@ -253,12 +256,15 @@ def test_nested_message_field():
     assert "__timestamp__" in event_capsule
     # Remove timestamp from capsule when checking equality, since it is gonna vary
     del event_capsule["__timestamp__"]
-    assert event_capsule == {
+    expected = {
         "__schema__": "http://test/test",
         "__schema_version__": 1,
         "__metadata_version__": 1,
         "thing": {"message": "a nested message was seen"},
     }
+    if sys.version_info >= (3, 12):
+        expected["taskName"] = None
+    assert event_capsule == expected
 
 
 def test_register_event_schema(tmp_path):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,6 +1,7 @@
 import io
 import json
 import logging
+import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 


### PR DESCRIPTION
Fixes warning:
```
DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
```

See: https://github.com/jupyterlab/jupyter-collaboration/actions/runs/5533655455/jobs/10097501386?pr=175#step:6:97

This PR is ready, but merging will:

- bump the minimum version of `jsonschema` to v4.18. See the changelog https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst#v4180
- drop support for Python v3.7, which the new `referencing` library doesn't support it.