### PR TITLE
Add more PyPI URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ file = 'LICENSE'
 
 [project.urls]
 Homepage = "http://jupyter.org"
+documentation = "https://jupyter-events.readthedocs.io/"
+repository = "https://github.com/jupyter/jupyter_events.git"
+changelog = "https://github.com/jupyter/jupyter_events/blob/main/CHANGELOG.md"
 
 [project.scripts]
 jupyter-events = "jupyter_events.cli:main"


### PR DESCRIPTION
For users being able to quickly find on PyPI links to source code, change logs, and documentation is really useful. This pull request adds to the pyproject.toml file the following:

- documentation
- repository
- changelog

These will be added below the "Homepage" link on PyPI:
<img width="291" alt="Screenshot 2023-08-01 at 10 18 53 AM" src="https://github.com/jupyter/jupyter_events/assets/62857/cbe31b68-c3f6-497f-bfb7-a730f87e25c6">