### PR TITLE
Allow for string annotations in listener signature

### DIFF
--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -278,9 +278,16 @@ class EventLogger(LoggingConfigurable):
             """An interface for a listener."""
             ...
 
+        async def listener_signature_str_ann(
+            logger: "EventLogger", schema_id: "str", data: "dict"
+        ) -> "None":
+            """An interface for a listener."""
+            ...
+
         expected_signature = inspect.signature(listener_signature)
+        expected_signature_str_ann = inspect.signature(listener_signature_str_ann)
         # Assert this signature or raise an exception
-        if signature == expected_signature:
+        if signature in [expected_signature, expected_signature_str_ann]:
             # If the schema ID and version is given, only add
             # this modifier to that schema
             if schema_id:

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -38,6 +38,23 @@ async def test_listener_function(jp_event_logger, schema):
     assert len(event_logger._active_listeners) == 0
 
 
+async def test_listener_function_str_annotations(jp_event_logger, schema):
+    event_logger = jp_event_logger
+    listener_was_called = False
+
+    async def my_listener(logger: "EventLogger", schema_id: "str", data: "dict") -> "None":
+        nonlocal listener_was_called
+        listener_was_called = True
+
+    # Add the modifier
+    event_logger.add_listener(schema_id=schema.id, listener=my_listener)
+    event_logger.emit(schema_id=schema.id, data={"prop": "hello, world"})
+    await event_logger.gather_listeners()
+    assert listener_was_called
+    # Check that the active listeners are cleaned up.
+    assert len(event_logger._active_listeners) == 0
+
+
 async def test_remove_listener_function(jp_event_logger, schema):
     event_logger = jp_event_logger
     listener_was_called = False


### PR DESCRIPTION
Allows for listeners to be defined in files that use `from __future__ import annotations`.