### PR TITLE
Adopt sp-repo-review

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,11 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Run Tests on pypy
-        if: ${{ startsWith( matrix.python-version, 'pypy') }}
-        run: hatch run test:test
       - name: Run Tests
-        if: ${{ ! startsWith( matrix.python-version, 'pypy') }}
         run: hatch run cov:test
       - uses: jupyterlab/maintainer-tools/.github/actions/upload-coverage@v1
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Run Tests on pypy
+        if: ${{ startsWith( matrix.python-version, 'pypy') }}
+        run: hatch run test:test
       - name: Run Tests
+        if: ${{ ! startsWith( matrix.python-version, 'pypy') }}
         run: hatch run cov:test
       - uses: jupyterlab/maintainer-tools/.github/actions/upload-coverage@v1
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -56,8 +56,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      -  name: Run Linters
-         run: |
+      - name: Run Linters
+        run: |
           hatch run typing:test
           hatch run lint:style
           pipx run interrogate .
@@ -83,7 +83,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: minimum
-      - name: Install with miniumum versions and optional deps
+      - name: Install with minimum versions and optional deps
         run: |
           pip install -e .[test]
           pip install jsonschema[format-nongpl,format_nongpl]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==23.7.0]
+        exclude: docs/user_guide/application.md
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.9.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ci:
   autoupdate_schedule: monthly
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -28,14 +29,47 @@ repos:
     rev: 0.7.17
     hooks:
       - id: mdformat
+        additional_dependencies:
+          [mdformat-gfm, mdformat-frontmatter, mdformat-footnote]
 
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.0.3"
+    hooks:
+      - id: prettier
+        types_or: [yaml, html, json]
+
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: "1.16.0"
+    hooks:
+      - id: blacken-docs
+        additional_dependencies: [black==23.7.0]
+
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.9.1
     hooks:
       - id: black
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: "v2.2.6"
+    hooks:
+      - id: codespell
+        args: ["-L", "sur,nd"]
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: "v1.10.0"
+    hooks:
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.292
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: ["--fix", "--show-fixes"]
+
+  - repo: https://github.com/scientific-python/cookie
+    rev: "2023.09.21"
+    hooks:
+      - id: sp-repo-review
+        additional_dependencies: ["repo-review[cli]"]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+sphinx:
+  configuration: docs/source/conf.py
+python:
+  install:
+    # install itself with pip install .
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/demo/demo-notebook.ipynb
+++ b/docs/demo/demo-notebook.ipynb
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# We will import one of the handlers from Python's logging libray\n",
+    "# We will import one of the handlers from Python's logging library\n",
     "from logging import StreamHandler\n",
     "\n",
     "handler = StreamHandler()\n",

--- a/docs/user_guide/application.md
+++ b/docs/user_guide/application.md
@@ -9,7 +9,6 @@ from jupyter_events import Event
 
 
 class MyApplication(JupyterApp):
-
     classes = [EventLogger, ...]
     eventlogger = Instance(EventLogger)
 
@@ -21,32 +20,32 @@ class MyApplication(JupyterApp):
 Register an event schema with the logger.
 
 ```python
-        schema = """
-        $id: http://myapplication.org/my-method
-        version: 1
-        title: My Method Executed
-        description: My method was executed one time.
-        properties:
-        msg:
-            title: Message
-            type: string
-        """
+schema = """
+$id: http://myapplication.org/my-method
+version: 1
+title: My Method Executed
+description: My method was executed one time.
+properties:
+msg:
+    title: Message
+    type: string
+"""
 
-        self.eventlogger.register_event_schema(
-            schema=schema
-        )
+self.eventlogger.register_event_schema(schema=schema)
 ```
 
 Call `.emit(...)` within the application to emit an instance of the event.
 
 ```python
-    def my_method(self):
-        # Do something
-        ...
-        # Emit event telling listeners that this event happened.
-        self.eventlogger.emit(schema_id="myapplication.org/my-method", data={"msg": "Hello, world!"})
-        # Do something else...
-        ...
+def my_method(self):
+    # Do something
+    ...
+    # Emit event telling listeners that this event happened.
+    self.eventlogger.emit(
+        schema_id="myapplication.org/my-method", data={"msg": "Hello, world!"}
+    )
+    # Do something else...
+    ...
 ```
 
 Great! Now your application is logging events from within. Deployers of your application can configure the system to listen to this event using Jupyter's configuration system. This usually means reading a `jupyter_config.py` file like this:

--- a/docs/user_guide/application.md
+++ b/docs/user_guide/application.md
@@ -20,32 +20,32 @@ class MyApplication(JupyterApp):
 Register an event schema with the logger.
 
 ```python
-schema = """
-$id: http://myapplication.org/my-method
-version: 1
-title: My Method Executed
-description: My method was executed one time.
-properties:
-msg:
-    title: Message
-    type: string
-"""
+        schema = """
+        $id: http://myapplication.org/my-method
+        version: 1
+        title: My Method Executed
+        description: My method was executed one time.
+        properties:
+        msg:
+            title: Message
+            type: string
+        """
 
-self.eventlogger.register_event_schema(schema=schema)
+        self.eventlogger.register_event_schema(schema=schema)
 ```
 
 Call `.emit(...)` within the application to emit an instance of the event.
 
 ```python
-def my_method(self):
-    # Do something
-    ...
-    # Emit event telling listeners that this event happened.
-    self.eventlogger.emit(
-        schema_id="myapplication.org/my-method", data={"msg": "Hello, world!"}
-    )
-    # Do something else...
-    ...
+    def my_method(self):
+        # Do something
+        ...
+        # Emit event telling listeners that this event happened.
+        self.eventlogger.emit(
+            schema_id="myapplication.org/my-method", data={"msg": "Hello, world!"}
+        )
+        # Do something else...
+        ...
 ```
 
 Great! Now your application is logging events from within. Deployers of your application can configure the system to listen to this event using Jupyter's configuration system. This usually means reading a `jupyter_config.py` file like this:

--- a/docs/user_guide/configure.md
+++ b/docs/user_guide/configure.md
@@ -9,7 +9,7 @@ This is usually done using a Jupyter configuration file, e.g. `jupyter_config.py
 from logging import FileHandler
 
 # Log events to a local file on disk.
-handler = FileHandler('events.txt')
+handler = FileHandler("events.txt")
 
 # Explicitly list the types of events
 # to record and what properties or what categories

--- a/docs/user_guide/event-schemas.md
+++ b/docs/user_guide/event-schemas.md
@@ -52,4 +52,4 @@ Schema: {
 
 The registry's validators will be used to check incoming events to ensure all outgoing, emitted events are registered and follow the expected form.
 
-Lastly, if an incoming event is not found in the registry, it does not get emitted. This ensures that we only collect data that we explicity register with the logger.
+Lastly, if an incoming event is not found in the registry, it does not get emitted. This ensures that we only collect data that we explicitly register with the logger.

--- a/docs/user_guide/first-event.md
+++ b/docs/user_guide/first-event.md
@@ -31,7 +31,7 @@ logger.register_event_schema(schema)
 Now that the logger knows about the event, it needs to know _where_ to send it. To do this, we register a logging _Handler_ —borrowed from Python's standard [`logging`](https://docs.python.org/3/library/logging.html) library—to route the events to the proper place.
 
 ```python
-# We will import one of the handlers from Python's logging libray
+# We will import one of the handlers from Python's logging library
 from logging import StreamHandler
 
 handler = StreamHandler()
@@ -45,11 +45,7 @@ The logger knows about the event and where to send it; all that's left is to emi
 from jupyter_events import Event
 
 logger.emit(
-      schema_id="http://myapplication.org/example-event",
-      data={
-         "name": "My Event"
-      }
-   )
+    schema_id="http://myapplication.org/example-event", data={"name": "My Event"}
 )
 ```
 

--- a/docs/user_guide/listeners.md
+++ b/docs/user_guide/listeners.md
@@ -11,6 +11,7 @@ Define a listener (async) function:
 ```python
 from jupyter_events.logger import EventLogger
 
+
 async def my_listener(logger: EventLogger, schema_id: str, data: dict) -> None:
     print("hello, from my listener")
 ```
@@ -18,7 +19,9 @@ async def my_listener(logger: EventLogger, schema_id: str, data: dict) -> None:
 Hook this listener to a specific event type:
 
 ```python
-event_logger.add_listener(schema_id="http://event.jupyter.org/my-event", listener=my_listener)
+event_logger.add_listener(
+    schema_id="http://event.jupyter.org/my-event", listener=my_listener
+)
 ```
 
 Now, every time a `"http://event.jupyter.org/test"` event is emitted from the EventLogger, this listener will be called.

--- a/jupyter_events/cli.py
+++ b/jupyter_events/cli.py
@@ -21,7 +21,7 @@ class RC:
 
     OK = 0
     INVALID = 1
-    UNPARSEABLE = 2
+    UNPARSABLE = 2
     NOT_FOUND = 3
 
 
@@ -38,7 +38,7 @@ error_console = Console(stderr=True)
 
 @click.group()
 @click.version_option()
-def main():
+def main() -> None:
     """A simple CLI tool to quickly validate JSON schemas against
     Jupyter Event's custom validator.
 
@@ -77,7 +77,7 @@ def validate(ctx: click.Context, schema: str) -> int:
             # no need for full tracestack for user error exceptions. just print
             # the error message and return
             error_console.print(f"[bold red]ERROR[/]: {e}")
-            return ctx.exit(RC.UNPARSEABLE)
+            return ctx.exit(RC.UNPARSABLE)
 
     # Print what was found.
     schema_json = JSON(json.dumps(_schema))
@@ -93,7 +93,7 @@ def validate(ctx: click.Context, schema: str) -> int:
         error_console.rule("Results", style=Style(color="red"))
         error_console.print(f"[red]{EMOJI.X} [white]The schema failed to validate.")
         error_console.print("\nWe found the following error with your schema:")
-        out = escape(str(err))  # type:ignore
+        out = escape(str(err))  # type:ignore[assignment]
         error_console.print(Padding(out, (1, 0, 1, 4)))
         return ctx.exit(RC.INVALID)
 

--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -12,7 +12,7 @@ import warnings
 from datetime import datetime, timezone
 
 from jsonschema import ValidationError
-from pythonjsonlogger import jsonlogger  # type:ignore[import-untyped]
+from pythonjsonlogger import jsonlogger
 from traitlets import Dict, Instance, Set, default
 from traitlets.config import Config, LoggingConfigurable
 
@@ -169,7 +169,7 @@ class EventLogger(LoggingConfigurable):
                 del record["message"]
             return json.dumps(record, **kwargs)
 
-        formatter = jsonlogger.JsonFormatter(
+        formatter = jsonlogger.JsonFormatter(  # type:ignore [no-untyped-call]
             json_serializer=_handle_message_field,
         )
         handler.setFormatter(formatter)

--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -1,17 +1,18 @@
 """
 Emit structured, discrete events when various actions happen.
 """
+from __future__ import annotations
+
 import asyncio
 import copy
-import inspect
 import json
 import logging
+import typing as t
 import warnings
 from datetime import datetime, timezone
-from typing import Any, Callable, Coroutine, Optional, Union
 
 from jsonschema import ValidationError
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger import jsonlogger  # type:ignore[import]
 from traitlets import Dict, Instance, Set, default
 from traitlets.config import Config, LoggingConfigurable
 
@@ -86,17 +87,19 @@ class EventLogger(LoggingConfigurable):
         {}, help="A mapping of schemas to the listeners of unmodified/raw events."
     )
 
-    _active_listeners = Set()
+    _active_listeners: set[asyncio.Task[t.Any]] = Set()  # type:ignore[assignment]
 
-    async def gather_listeners(self):
+    async def gather_listeners(self) -> list[t.Any]:
         """Gather all of the active listeners."""
-        return await asyncio.gather(*self._active_listeners, return_exceptions=True)
+        return await asyncio.gather(  # type:ignore[no-any-return]
+            *self._active_listeners, return_exceptions=True
+        )
 
     @default("schemas")
     def _default_schemas(self) -> SchemaRegistry:
         return SchemaRegistry()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
         """Initialize the logger."""
         # We need to initialize the configurable before
         # adding the logging handlers.
@@ -114,15 +117,20 @@ class EventLogger(LoggingConfigurable):
             for handler in self.handlers:
                 self.register_handler(handler)
 
-    def _load_config(self, cfg, section_names=None, traits=None):
+    def _load_config(
+        self,
+        cfg: Config,
+        section_names: list[str] | None = None,
+        traits: list[str] | None = None,
+    ) -> None:
         """Load EventLogger traits from a Config object, patching the
         handlers trait in the Config object to avoid deepcopy errors.
         """
         my_cfg = self._find_my_config(cfg)
-        handlers = my_cfg.pop("handlers", [])
+        handlers: list[logging.Handler] = my_cfg.pop("handlers", [])
 
         # Turn handlers list into a pickeable function
-        def get_handlers():
+        def get_handlers() -> list[logging.Handler]:
             return handlers
 
         my_cfg["handlers"] = get_handlers
@@ -149,7 +157,7 @@ class EventLogger(LoggingConfigurable):
         All outgoing messages will be formatted as a JSON string.
         """
 
-        def _handle_message_field(record, **kwargs):
+        def _handle_message_field(record: t.Any, **kwargs: t.Any) -> str:
             """Python's logger always emits the "message" field with
             the value as "null" unless it's present in the schema/data.
             Message happens to be a common field for event logs,
@@ -178,8 +186,8 @@ class EventLogger(LoggingConfigurable):
     def add_modifier(
         self,
         *,
-        schema_id: Union[str, None] = None,
-        modifier: Callable[[str, dict], dict],
+        schema_id: str | None = None,
+        modifier: t.Callable[[str, dict[str, t.Any]], dict[str, t.Any]],
     ) -> None:
         """Add a modifier (callable) to a registered event.
 
@@ -193,41 +201,23 @@ class EventLogger(LoggingConfigurable):
         """
         # Ensure that this is a callable function/method
         if not callable(modifier):
-            msg = "`modifier` must be a callable"
+            msg = "`modifier` must be a callable"  # type:ignore[unreachable]
             raise TypeError(msg)
 
-        # Now let's verify the function signature.
-        signature = inspect.signature(modifier)
-
-        def modifier_signature(  # type:ignore[empty-body]
-            schema_id: str, data: dict
-        ) -> dict:
-            """Signature to enforce"""
-            ...
-
-        expected_signature = inspect.signature(modifier_signature)
-        # Assert this signature or raise an exception
-        if signature == expected_signature:
-            # If the schema ID and version is given, only add
-            # this modifier to that schema
-            if schema_id:
-                self._modifiers[schema_id].add(modifier)
-                return
-            for id_ in self._modifiers:
-                if schema_id is None or id_ == schema_id:
-                    self._modifiers[id_].add(modifier)
-        else:
-            msg = (
-                "Modifiers are required to follow an exact function/method "
-                "signature. The signature should look like:"
-                f"\n\n\tdef my_modifier{expected_signature}:\n\n"
-                "Check that you are using type annotations for each argument "
-                "and the return value."
-            )
-            raise ModifierError(msg)
+        # If the schema ID and version is given, only add
+        # this modifier to that schema
+        if schema_id:
+            self._modifiers[schema_id].add(modifier)
+            return
+        for id_ in self._modifiers:
+            if schema_id is None or id_ == schema_id:
+                self._modifiers[id_].add(modifier)
 
     def remove_modifier(
-        self, *, schema_id: Optional[str] = None, modifier: Callable[[str, dict], dict]
+        self,
+        *,
+        schema_id: str | None = None,
+        modifier: t.Callable[[str, dict[str, t.Any]], dict[str, t.Any]],
     ) -> None:
         """Remove a modifier from an event or all events.
 
@@ -253,8 +243,8 @@ class EventLogger(LoggingConfigurable):
         self,
         *,
         modified: bool = True,
-        schema_id: Union[str, None] = None,
-        listener: Callable[["EventLogger", str, dict], Coroutine[Any, Any, None]],
+        schema_id: str | None = None,
+        listener: t.Callable[[EventLogger, str, dict[str, t.Any]], t.Coroutine[t.Any, t.Any, None]],
     ) -> None:
         """Add a listener (callable) to a registered event.
 
@@ -269,54 +259,28 @@ class EventLogger(LoggingConfigurable):
             A callable function/method that executes when the named event occurs.
         """
         if not callable(listener):
-            msg = "`listener` must be a callable"
+            msg = "`listener` must be a callable"  # type:ignore[unreachable]
             raise TypeError(msg)
 
-        signature = inspect.signature(listener)
-
-        async def listener_signature(logger: EventLogger, schema_id: str, data: dict) -> None:
-            """An interface for a listener."""
-            ...
-
-        async def listener_signature_str_ann(
-            logger: "EventLogger", schema_id: "str", data: "dict"
-        ) -> "None":
-            """An interface for a listener."""
-            ...
-
-        expected_signature = inspect.signature(listener_signature)
-        expected_signature_str_ann = inspect.signature(listener_signature_str_ann)
-        # Assert this signature or raise an exception
-        if signature in [expected_signature, expected_signature_str_ann]:
-            # If the schema ID and version is given, only add
-            # this modifier to that schema
-            if schema_id:
+        # If the schema ID and version is given, only add
+        # this modifier to that schema
+        if schema_id:
+            if modified:
+                self._modified_listeners[schema_id].add(listener)
+                return
+            self._unmodified_listeners[schema_id].add(listener)
+        for id_ in self.schemas.schema_ids:
+            if schema_id is None or id_ == schema_id:
                 if modified:
-                    self._modified_listeners[schema_id].add(listener)
-                    return
-                self._unmodified_listeners[schema_id].add(listener)
-            for id_ in self.schemas.schema_ids:
-                if schema_id is None or id_ == schema_id:
-                    if modified:
-                        self._modified_listeners[id_].add(listener)
-                    else:
-                        self._unmodified_listeners[schema_id].add(listener)
-        else:
-            msg = (
-                "Listeners are required to follow an exact function/method "
-                "signature. The signature should look like:"
-                f"\n\n\tasync def my_listener{expected_signature}:\n\n"
-                "Check that you are using type annotations for each argument "
-                "and the return value."
-            )
-
-            raise ListenerError(msg)
+                    self._modified_listeners[id_].add(listener)
+                else:
+                    self._unmodified_listeners[schema_id].add(listener)
 
     def remove_listener(
         self,
         *,
-        schema_id: Optional[str] = None,
-        listener: Callable[["EventLogger", str, dict], Coroutine[Any, Any, None]],
+        schema_id: str | None = None,
+        listener: t.Callable[[EventLogger, str, dict[str, t.Any]], t.Coroutine[t.Any, t.Any, None]],
     ) -> None:
         """Remove a listener from an event or all events.
 
@@ -340,8 +304,8 @@ class EventLogger(LoggingConfigurable):
                 self._unmodified_listeners[schema_id].discard(listener)
 
     def emit(
-        self, *, schema_id: str, data: dict, timestamp_override: Optional[datetime] = None
-    ) -> Optional[dict]:
+        self, *, schema_id: str, data: dict[str, t.Any], timestamp_override: datetime | None = None
+    ) -> dict[str, t.Any] | None:
         """
         Record given event with schema has occurred.
 
@@ -414,7 +378,7 @@ class EventLogger(LoggingConfigurable):
 
         # callback for removing from finished listeners
         # from active listeners set.
-        def _listener_task_done(task: asyncio.Task) -> None:
+        def _listener_task_done(task: asyncio.Task[t.Any]) -> None:
             # If an exception happens, log it to the main
             # applications logger
             err = task.exception()
@@ -443,7 +407,7 @@ class EventLogger(LoggingConfigurable):
             self._active_listeners.add(task)
 
             # Remove task from active listeners once its finished.
-            def _listener_task_done(task: asyncio.Task) -> None:
+            def _listener_task_done(task: asyncio.Task[t.Any]) -> None:
                 # If an exception happens, log it to the main
                 # applications logger
                 err = task.exception()

--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -12,7 +12,7 @@ import warnings
 from datetime import datetime, timezone
 
 from jsonschema import ValidationError
-from pythonjsonlogger import jsonlogger  # type:ignore[import]
+from pythonjsonlogger import jsonlogger  # type:ignore[import-untyped]
 from traitlets import Dict, Instance, Set, default
 from traitlets.config import Config, LoggingConfigurable
 

--- a/jupyter_events/pytest_plugin.py
+++ b/jupyter_events/pytest_plugin.py
@@ -1,7 +1,10 @@
 """Fixtures for use with jupyter events."""
+from __future__ import annotations
+
 import io
 import json
 import logging
+from typing import Any, Callable
 
 import pytest
 
@@ -9,22 +12,24 @@ from jupyter_events import EventLogger
 
 
 @pytest.fixture
-def jp_event_sink():
+def jp_event_sink() -> io.StringIO:
     """A stream for capture events."""
     return io.StringIO()
 
 
 @pytest.fixture
-def jp_event_handler(jp_event_sink):
+def jp_event_handler(jp_event_sink: io.StringIO) -> logging.Handler:
     """A logging handler that captures any events emitted by the event handler"""
     return logging.StreamHandler(jp_event_sink)
 
 
 @pytest.fixture
-def jp_read_emitted_events(jp_event_handler, jp_event_sink):
+def jp_read_emitted_events(
+    jp_event_handler: logging.Handler, jp_event_sink: io.StringIO
+) -> Callable[..., list[str] | None]:
     """Reads list of events since last time it was called."""
 
-    def _read():
+    def _read() -> list[str] | None:
         jp_event_handler.flush()
         event_buf = jp_event_sink.getvalue().strip()
         output = [json.loads(item) for item in event_buf.split("\n")] if event_buf else None
@@ -37,7 +42,7 @@ def jp_read_emitted_events(jp_event_handler, jp_event_sink):
 
 
 @pytest.fixture
-def jp_event_schemas():
+def jp_event_schemas() -> list[Any]:
     """A list of schema references.
 
     Each item should be one of the following:
@@ -49,7 +54,7 @@ def jp_event_schemas():
 
 
 @pytest.fixture
-def jp_event_logger(jp_event_handler, jp_event_schemas):
+def jp_event_logger(jp_event_handler: logging.Handler, jp_event_schemas: list[Any]) -> EventLogger:
     """A pre-configured event logger for tests."""
     logger = EventLogger()
     for schema in jp_event_schemas:

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -128,32 +128,32 @@ class EventSchema:
 
             loaded_schema = yaml.load(schema)
             EventSchema._ensure_yaml_loaded(loaded_schema)
-            return loaded_schema
+            return loaded_schema  # type:ignore[no-any-return]
 
         # finally, if schema is string, attempt to deserialize and return the output
         if isinstance(schema, str):
             # note the diff b/w load v.s. loads
             loaded_schema = yaml.loads(schema)
             EventSchema._ensure_yaml_loaded(loaded_schema, was_str=True)
-            return loaded_schema
+            return loaded_schema  # type:ignore[no-any-return]
 
-        msg = f"Expected a dictionary, string, or PurePath, but instead received {schema.__class__.__name__}."
+        msg = f"Expected a dictionary, string, or PurePath, but instead received {schema.__class__.__name__}."  # type:ignore[unreachable]
         raise EventSchemaUnrecognized(msg)
 
     @property
     def id(self) -> str:  # noqa
         """Schema $id field."""
-        return self._schema["$id"]
+        return self._schema["$id"]  # type:ignore[no-any-return]
 
     @property
     def version(self) -> int:
         """Schema's version."""
-        return self._schema["version"]
+        return self._schema["version"]  # type:ignore[no-any-return]
 
     @property
-    def properties(self) -> dict:
-        return self._schema["properties"]
+    def properties(self) -> dict[str, Any]:
+        return self._schema["properties"]  # type:ignore[no-any-return]
 
-    def validate(self, data: dict) -> None:
+    def validate(self, data: dict[str, Any]) -> None:
         """Validate an incoming instance of this event schema."""
         self._validator.validate(data)

--- a/jupyter_events/schema.py
+++ b/jupyter_events/schema.py
@@ -1,7 +1,9 @@
 """Event schema objects."""
+from __future__ import annotations
+
 import json
 from pathlib import Path, PurePath
-from typing import Optional, Type, Union
+from typing import Any, Union
 
 from jsonschema import FormatChecker, validators
 from referencing import Registry
@@ -10,9 +12,7 @@ from referencing.jsonschema import DRAFT7
 try:
     from jsonschema.protocols import Validator
 except ImportError:
-    from typing import Any
-
-    Validator = Any  # type:ignore
+    Validator = Any  # type:ignore[assignment, misc]
 
 from . import yaml
 from .validators import draft7_format_checker, validate_schema
@@ -64,9 +64,9 @@ class EventSchema:
     def __init__(
         self,
         schema: SchemaType,
-        validator_class: Type[Validator] = validators.Draft7Validator,  # type:ignore[assignment]
+        validator_class: type[Validator] = validators.Draft7Validator,  # type:ignore[assignment]
         format_checker: FormatChecker = draft7_format_checker,
-        registry: Optional[Registry] = None,
+        registry: Registry[Any] | None = None,
     ):
         """Initialize an event schema."""
         _schema = self._load_schema(schema)
@@ -77,10 +77,10 @@ class EventSchema:
             registry = DRAFT7.create_resource(_schema) @ Registry()
 
         # Create a validator for this schema
-        self._validator = validator_class(_schema, registry=registry, format_checker=format_checker)  # type: ignore
+        self._validator = validator_class(_schema, registry=registry, format_checker=format_checker)  # type: ignore[call-arg]
         self._schema = _schema
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """A string repr for an event schema."""
         return json.dumps(self._schema, indent=2)
 
@@ -107,7 +107,7 @@ class EventSchema:
         raise EventSchemaLoadingError(error_msg)
 
     @staticmethod
-    def _load_schema(schema: SchemaType) -> dict:
+    def _load_schema(schema: SchemaType) -> dict[str, Any]:
         """Load a JSON schema from different sources/data types.
 
         `schema` could be a dictionary or serialized string representing the

--- a/jupyter_events/schema_registry.py
+++ b/jupyter_events/schema_registry.py
@@ -1,5 +1,7 @@
 """"An event schema registry."""
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from .schema import EventSchema
 
@@ -11,9 +13,9 @@ class SchemaRegistryException(Exception):  # noqa: N818
 class SchemaRegistry:
     """A convenient API for storing and searching a group of schemas."""
 
-    def __init__(self, schemas: Optional[dict] = None):
+    def __init__(self, schemas: dict[str, EventSchema] | None = None):
         """Initialize the registry."""
-        self._schemas = schemas or {}
+        self._schemas: dict[str, EventSchema] = schemas or {}
 
     def __contains__(self, key: str) -> bool:
         """Syntax sugar to check if a schema is found in the registry"""
@@ -33,10 +35,10 @@ class SchemaRegistry:
         self._schemas[schema_obj.id] = schema_obj
 
     @property
-    def schema_ids(self):
-        return self._schemas.keys()
+    def schema_ids(self) -> list[str]:
+        return list(self._schemas.keys())
 
-    def register(self, schema: Union[dict, str, EventSchema]) -> EventSchema:
+    def register(self, schema: dict[str, Any] | (str | EventSchema)) -> EventSchema:
         """Add a valid schema to the registry.
 
         All schemas are validated against the Jupyter Events meta-schema
@@ -73,7 +75,7 @@ class SchemaRegistry:
             )
             raise KeyError(msg) from None
 
-    def validate_event(self, id_: str, data: dict) -> None:
+    def validate_event(self, id_: str, data: dict[str, Any]) -> None:
         """Validate an event against a schema within this
         registry.
         """

--- a/jupyter_events/traits.py
+++ b/jupyter_events/traits.py
@@ -1,11 +1,17 @@
 """Trait types for events."""
+from __future__ import annotations
+
 import logging
 import typing as t
 
 from traitlets import TraitError, TraitType
 
+baseclass = TraitType
+if t.TYPE_CHECKING:
+    baseclass = TraitType[t.Any, t.Any]
 
-class Handlers(TraitType[t.Any, t.Any]):
+
+class Handlers(baseclass):
     """A trait that takes a list of logging handlers and converts
     it to a callable that returns that list (thus, making this
     trait pickleable).

--- a/jupyter_events/traits.py
+++ b/jupyter_events/traits.py
@@ -1,10 +1,11 @@
 """Trait types for events."""
 import logging
+import typing as t
 
 from traitlets import TraitError, TraitType
 
 
-class Handlers(TraitType):
+class Handlers(TraitType[t.Any, t.Any]):
     """A trait that takes a list of logging handlers and converts
     it to a callable that returns that list (thus, making this
     trait pickleable).
@@ -12,7 +13,7 @@ class Handlers(TraitType):
 
     info_text = "a list of logging handlers"
 
-    def validate_elements(self, obj, value):
+    def validate_elements(self, obj: t.Any, value: t.Any) -> None:
         """Validate the elements of an object."""
         if len(value) > 0:
             # Check that all elements are logging handlers.
@@ -20,12 +21,12 @@ class Handlers(TraitType):
                 if isinstance(el, logging.Handler) is False:
                     self.element_error(obj)
 
-    def element_error(self, obj):
+    def element_error(self, obj: t.Any) -> None:
         """Raise an error for bad elements."""
         msg = f"Elements in the '{self.name}' trait of an {obj.__class__.__name__} instance must be Python `logging` handler instances."
         raise TraitError(msg)
 
-    def validate(self, obj, value):
+    def validate(self, obj: t.Any, value: t.Any) -> t.Any:
         """Validate an object."""
         # If given a callable, call it and set the
         # value of this trait to the returned list.
@@ -41,4 +42,4 @@ class Handlers(TraitType):
             self.validate_elements(obj, value)
             return value
         else:
-            self.error(obj, value)
+            self.error(obj, value)  # type:ignore[no-untyped-call]

--- a/jupyter_events/traits.py
+++ b/jupyter_events/traits.py
@@ -8,10 +8,10 @@ from traitlets import TraitError, TraitType
 
 baseclass = TraitType
 if t.TYPE_CHECKING:
-    baseclass = TraitType[t.Any, t.Any]
+    baseclass = TraitType[t.Any, t.Any]  # type:ignore[misc]
 
 
-class Handlers(baseclass):
+class Handlers(baseclass):  # type:ignore[type-arg]
     """A trait that takes a list of logging handlers and converts
     it to a callable that returns that list (thus, making this
     trait pickleable).

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -1,5 +1,8 @@
 """Event validators."""
+from __future__ import annotations
+
 import pathlib
+from typing import Any
 
 import jsonschema
 from jsonschema import Draft7Validator, ValidationError
@@ -36,22 +39,22 @@ resources = [
     DRAFT7.create_resource(each)
     for each in (EVENT_METASCHEMA, PROPERTY_METASCHEMA, EVENT_CORE_SCHEMA)
 ]
-METASCHEMA_REGISTRY: Registry = resources @ Registry()
+METASCHEMA_REGISTRY: Registry[Any] = resources @ Registry()
 
 JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(
     schema=EVENT_METASCHEMA,
-    registry=METASCHEMA_REGISTRY,
+    registry=METASCHEMA_REGISTRY,  # type:ignore[call-arg]
     format_checker=draft7_format_checker,
 )
 
 JUPYTER_EVENTS_CORE_VALIDATOR = Draft7Validator(
     schema=EVENT_CORE_SCHEMA,
-    registry=METASCHEMA_REGISTRY,
+    registry=METASCHEMA_REGISTRY,  # type:ignore[call-arg]
     format_checker=draft7_format_checker,
 )
 
 
-def validate_schema(schema: dict) -> None:
+def validate_schema(schema: dict[str, Any]) -> None:
     """Validate a schema dict."""
     try:
         # Validate the schema against Jupyter Events metaschema.

--- a/jupyter_events/validators.py
+++ b/jupyter_events/validators.py
@@ -43,13 +43,13 @@ METASCHEMA_REGISTRY: Registry[Any] = resources @ Registry()
 
 JUPYTER_EVENTS_SCHEMA_VALIDATOR = Draft7Validator(
     schema=EVENT_METASCHEMA,
-    registry=METASCHEMA_REGISTRY,  # type:ignore[call-arg]
+    registry=METASCHEMA_REGISTRY,
     format_checker=draft7_format_checker,
 )
 
 JUPYTER_EVENTS_CORE_VALIDATOR = Draft7Validator(
     schema=EVENT_CORE_SCHEMA,
-    registry=METASCHEMA_REGISTRY,  # type:ignore[call-arg]
+    registry=METASCHEMA_REGISTRY,
     format_checker=draft7_format_checker,
 )
 

--- a/jupyter_events/yaml.py
+++ b/jupyter_events/yaml.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path, PurePath
-from typing import Any, cast
+from typing import Any
 
 from yaml import dump as ydump
 from yaml import load as yload
@@ -21,7 +21,7 @@ def loads(stream: Any) -> Any:
 
 def dumps(stream: Any) -> str:
     """Parse the first YAML document in a stream as an object."""
-    return cast(str, ydump(stream, Dumper=SafeDumper))
+    return ydump(stream, Dumper=SafeDumper)
 
 
 def load(fpath: str | PurePath) -> Any:

--- a/jupyter_events/yaml.py
+++ b/jupyter_events/yaml.py
@@ -1,6 +1,8 @@
 """Yaml utilities."""
-# mypy: ignore-errors
-from pathlib import Path
+from __future__ import annotations
+
+from pathlib import Path, PurePath
+from typing import Any, cast
 
 from yaml import dump as ydump
 from yaml import load as yload
@@ -9,26 +11,26 @@ try:
     from yaml import CSafeDumper as SafeDumper
     from yaml import CSafeLoader as SafeLoader
 except ImportError:  # pragma: no cover
-    from yaml import SafeDumper, SafeLoader
+    from yaml import SafeDumper, SafeLoader  # type:ignore[assignment]
 
 
-def loads(stream):
+def loads(stream: Any) -> Any:
     """Load yaml from a stream."""
     return yload(stream, Loader=SafeLoader)
 
 
-def dumps(stream):
+def dumps(stream: Any) -> str:
     """Parse the first YAML document in a stream as an object."""
-    return ydump(stream, Dumper=SafeDumper)
+    return cast(str, ydump(stream, Dumper=SafeDumper))
 
 
-def load(fpath):
+def load(fpath: str | PurePath) -> Any:
     """Load yaml from a file."""
     # coerce PurePath into Path, then read its contents
     data = Path(str(fpath)).read_text(encoding="utf-8")
     return loads(data)
 
 
-def dump(data, outpath):
+def dump(data: Any, outpath: str | PurePath) -> None:
     """Parse the a YAML document in a file as an object."""
     Path(outpath).write_text(dumps(data), encoding="utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,8 @@ filterwarnings= [
   "error",
   # Upstream warnings from python-dateutil
   "module:datetime.datetime.utc:DeprecationWarning",
+  # Ignore importwarning on pypy for yaml
+  "module:can't resolve package from __spec__ or __package__:ImportWarning",
 ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,9 @@ nowarn = "test -W default {args}"
 
 [tool.hatch.envs.typing]
 features = ["test"]
-dependencies = ["mypy>=0.990"]
+dependencies = ["mypy>=1.5.1", "traitlets>=5.11.1"]
 [tool.hatch.envs.typing.scripts]
-test = "mypy --install-types --non-interactive {args:.}"
+test = "mypy --install-types --non-interactive {args}"
 
 [tool.hatch.envs.lint]
 dependencies = ["black[jupyter]==23.3.0", "mdformat>0.7", "ruff==0.0.287"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,12 +114,22 @@ fmt = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-raXs --durations 10 --color=yes --doctest-modules"
+minversion = "6.0"
+xfail_strict = true
+log_cli_level = "info"
+addopts = [
+  "-raXs", "--durations=10", "--color=yes", "--doctest-modules",
+   "--showlocals", "--strict-markers", "--strict-config"
+]
 testpaths = [
     "tests/"
 ]
 asyncio_mode = "auto"
 script_launch_mode = "subprocess"
+filterwarnings= [
+  # Fail on warnings
+  "error",
+]
 
 [tool.coverage.report]
 exclude_lines = [
@@ -140,18 +150,12 @@ relative_files = true
 source = ["jupyter_events"]
 
 [tool.mypy]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-no_implicit_optional = true
-pretty = true
-show_error_context = true
+files = "jupyter_events"
+python_version = "3.8"
+strict = true
 show_error_codes = true
-strict_equality = true
-warn_unused_configs = true
-warn_unused_ignores = true
-warn_redundant_casts = true
-explicit_package_bases = true
-namespace_packages = true
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+warn_unreachable = true
 
 [tool.black]
 line-length = 100
@@ -207,3 +211,6 @@ ignore-nested-functions=true
 ignore-nested-classes=true
 fail-under=100
 exclude = ["docs", "tests"]
+
+[tool.repo-review]
+ignore = ["PY007", "PP308", "GH102", "PC140"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ nowarn = "test -W default {args}"
 
 [tool.hatch.envs.typing]
 features = ["test"]
-dependencies = ["mypy>=1.5.1", "traitlets>=5.11.1"]
+dependencies = ["mypy~=1.6", "traitlets>=5.11.1", "jupyter_core>=5.4"]
 [tool.hatch.envs.typing.scripts]
 test = "mypy --install-types --non-interactive {args}"
 
@@ -129,6 +129,8 @@ script_launch_mode = "subprocess"
 filterwarnings= [
   # Fail on warnings
   "error",
+  # Upstream warnings from python-dateutil
+  "module:datetime.datetime.utc:DeprecationWarning",
 ]
 
 [tool.coverage.report]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ def cli(script_runner):
         env.update(kwargs.pop("env", {}))
         env["PYTHONIOENCODING"] = "utf-8"
         kwargs["env"] = env
-        return script_runner.run(NAME, *map(str, args), **kwargs)
+        return script_runner.run([NAME, *list(map(str, args))], **kwargs)
 
     return run_cli
 
@@ -54,14 +54,14 @@ def test_cli_good_raw(cli):
 def test_cli_missing(cli):
     ret = cli("validate", SCHEMA_PATH / "bad/doesnt-exist.yaml")
     assert not ret.success
-    assert ret.returncode == RC.UNPARSEABLE
+    assert ret.returncode == RC.UNPARSABLE
     assert "Schema file not present" in ret.stderr.strip()
 
 
 def test_cli_malformed(cli):
     ret = cli("validate", SCHEMA_PATH / "bad/invalid.yaml")
     assert not ret.success
-    assert ret.returncode == RC.UNPARSEABLE
+    assert ret.returncode == RC.UNPARSABLE
     assert "Could not deserialize" in ret.stderr.strip()
 
 

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -3,7 +3,7 @@ import logging
 
 import pytest
 
-from jupyter_events.logger import EventLogger, ListenerError
+from jupyter_events.logger import EventLogger
 from jupyter_events.schema import EventSchema
 
 from .utils import SCHEMA_PATH
@@ -74,24 +74,6 @@ async def test_remove_listener_function(jp_event_logger, schema):
 
     event_logger.remove_listener(listener=my_listener)
     assert len(event_logger._modified_listeners[schema.id]) == 0
-    assert len(event_logger._unmodified_listeners[schema.id]) == 0
-
-
-async def test_bad_listener_function_signature(jp_event_logger, schema):
-    event_logger = jp_event_logger
-
-    async def listener_with_extra_args(
-        logger: EventLogger, schema_id: str, data: dict, unknown_arg: dict
-    ) -> None:
-        pass
-
-    with pytest.raises(ListenerError):
-        event_logger.add_listener(
-            schema_id=schema.id,
-            listener=listener_with_extra_args,
-        )
-
-    # Ensure no modifier was added.
     assert len(event_logger._unmodified_listeners[schema.id]) == 0
 
 

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -1,6 +1,5 @@
 import pytest
 
-from jupyter_events.logger import EventLogger, ModifierError
 from jupyter_events.schema import EventSchema
 
 from .utils import SCHEMA_PATH
@@ -52,45 +51,6 @@ def test_modifier_method(schema, jp_event_logger, jp_read_emitted_events):
     output = jp_read_emitted_events()[0]
     assert "username" in output
     assert output["username"] == "<masked>"
-
-
-def test_bad_modifier_functions(jp_event_logger: EventLogger, schema: EventSchema) -> None:
-    event_logger = jp_event_logger
-
-    def modifier_with_extra_args(schema_id: str, data: dict, unknown_arg: dict) -> dict:
-        return data
-
-    with pytest.raises(ModifierError):
-        event_logger.add_modifier(modifier=modifier_with_extra_args)  # type:ignore[arg-type]
-
-    # Ensure no modifier was added.
-    assert len(event_logger._modifiers[schema.id]) == 0
-
-
-def test_bad_modifier_method(jp_event_logger: EventLogger, schema: EventSchema) -> None:
-    event_logger = jp_event_logger
-
-    class Redactor:
-        def redact(self, schema_id: str, data: dict, extra_args: dict) -> dict:
-            return data
-
-    redactor = Redactor()
-
-    with pytest.raises(ModifierError):
-        event_logger.add_modifier(modifier=redactor.redact)  # type:ignore[arg-type]
-
-    # Ensure no modifier was added
-    assert len(event_logger._modifiers[schema.id]) == 0
-
-
-def test_modifier_without_annotations():
-    logger = EventLogger()
-
-    def modifier_with_extra_args(event):
-        return event
-
-    with pytest.raises(ModifierError):
-        logger.add_modifier(modifier=modifier_with_extra_args)  # type:ignore[arg-type]
 
 
 def test_remove_modifier(schema, jp_event_logger, jp_read_emitted_events):


### PR DESCRIPTION
@Zsailer heads up, I dropped the use of `inspect.signature` since it doesn't mix well with `mypy` when `from __future__ import annotations` is used.  Now that we're embracing typing, the type checker should be the one enforcing the signature.