### PR TITLE
Enable adding listeners to event before the event is registered

### DIFF
--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -144,7 +144,7 @@ class EventLogger(LoggingConfigurable):
         """
         event_schema = self.schemas.register(schema)  # type:ignore[arg-type]
         key = event_schema.id
-        # It's possible that listeners and modifiers have been added for this 
+        # It's possible that listeners and modifiers have been added for this
         # schema before the schema is registered.
         if key not in self._modifiers:
             self._modifiers[key] = set()
@@ -209,7 +209,7 @@ class EventLogger(LoggingConfigurable):
         # If the schema ID and version is given, only add
         # this modifier to that schema
         if schema_id:
-            # If the schema hasn't been added yet, 
+            # If the schema hasn't been added yet,
             # start a placeholder set.
             modifiers = self._modifiers.get(schema_id, set())
             modifiers.add(modifier)
@@ -272,15 +272,15 @@ class EventLogger(LoggingConfigurable):
         # this modifier to that schema
         if schema_id:
             if modified:
-                # If the schema hasn't been added yet, 
+                # If the schema hasn't been added yet,
                 # start a placeholder set.
                 listeners = self._modified_listeners.get(schema_id, set())
                 listeners.add(listener)
-                self._modified_listeners[schema_id] = listeners 
+                self._modified_listeners[schema_id] = listeners
                 return
             listeners = self._unmodified_listeners.get(schema_id, set())
             listeners.add(listener)
-            self._unmodified_listeners[schema_id] = listeners 
+            self._unmodified_listeners[schema_id] = listeners
             return
         for id_ in self.schemas.schema_ids:
             if schema_id is None or id_ == schema_id:

--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -142,12 +142,16 @@ class EventLogger(LoggingConfigurable):
 
         Get this registered schema using the EventLogger.schema.get() method.
         """
-
         event_schema = self.schemas.register(schema)  # type:ignore[arg-type]
         key = event_schema.id
-        self._modifiers[key] = set()
-        self._modified_listeners[key] = set()
-        self._unmodified_listeners[key] = set()
+        # It's possible that listeners and modifiers have been added for this 
+        # schema before the schema is registered.
+        if key not in self._modifiers:
+            self._modifiers[key] = set()
+        if key not in self._modified_listeners:
+            self._modified_listeners[key] = set()
+        if key not in self._unmodified_listeners:
+            self._unmodified_listeners[key] = set()
 
     def register_handler(self, handler: logging.Handler) -> None:
         """Register a new logging handler to the Event Logger.
@@ -205,7 +209,11 @@ class EventLogger(LoggingConfigurable):
         # If the schema ID and version is given, only add
         # this modifier to that schema
         if schema_id:
-            self._modifiers[schema_id].add(modifier)
+            # If the schema hasn't been added yet, 
+            # start a placeholder set.
+            modifiers = self._modifiers.get(schema_id, set())
+            modifiers.add(modifier)
+            self._modifiers[schema_id] = modifiers
             return
         for id_ in self._modifiers:
             if schema_id is None or id_ == schema_id:
@@ -264,9 +272,16 @@ class EventLogger(LoggingConfigurable):
         # this modifier to that schema
         if schema_id:
             if modified:
-                self._modified_listeners[schema_id].add(listener)
+                # If the schema hasn't been added yet, 
+                # start a placeholder set.
+                listeners = self._modified_listeners.get(schema_id, set())
+                listeners.add(listener)
+                self._modified_listeners[schema_id] = listeners 
                 return
-            self._unmodified_listeners[schema_id].add(listener)
+            listeners = self._unmodified_listeners.get(schema_id, set())
+            listeners.add(listener)
+            self._unmodified_listeners[schema_id] = listeners 
+            return
         for id_ in self.schemas.schema_ids:
             if schema_id is None or id_ == schema_id:
                 if modified:

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -142,7 +142,11 @@ async def test_bad_listener_does_not_break_good_listener(jp_event_logger, schema
 
 @pytest.mark.parametrize(
     # Make sure no schemas are added at the start of this test.
-    "jp_event_schemas", ([],) 
+    "jp_event_schemas",
+    [
+        # Empty events list.
+        []
+    ],
 )
 async def test_listener_added_before_schemas_passes(jp_event_logger, schema):
     # Ensure there are no schemas listed.
@@ -164,7 +168,7 @@ async def test_listener_added_before_schemas_passes(jp_event_logger, schema):
     assert not listener_was_called
 
     # Now register the event and emit.
-    jp_event_logger.register_event_schema(schema)        
+    jp_event_logger.register_event_schema(schema)
 
     # Try emitting the event again and ensure the listener saw it.
     jp_event_logger.emit(schema_id=schema.id, data={"prop": "hello, world"})

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -162,7 +162,7 @@ async def test_listener_added_before_schemas_passes(jp_event_logger, schema):
     jp_event_logger.add_listener(schema_id=schema.id, listener=my_listener)
 
     # Proof that emitting the event won't success
-    with pytest.raises(SchemaNotRegistered):
+    with pytest.warns(SchemaNotRegistered):
         jp_event_logger.emit(schema_id=schema.id, data={"prop": "hello, world"})
 
     assert not listener_was_called


### PR DESCRIPTION
Currently, if listeners are added _before_ the event they are meant to watch is added, the listener gets removed when the event is registered. We should keep them around.

This showed up in work around jupyter server. 

If one extension (E1) wants to listen to events from another extension (E2), a problem arises is E2 is loaded _after_ E1 is loaded. This is a common use-case. jupyter server doesn't have a dependency injection system yet, so we can't name extension dependencies. 

Either way, I think the event logger show allow listeners to be added even if the event isn't registered yet. It's a no-op until the event is registered.