### PR TITLE
Update notebook to match current version of jupyter-events

### DIFF
--- a/docs/demo/demo-notebook.ipynb
+++ b/docs/demo/demo-notebook.ipynb
@@ -54,9 +54,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Validator class: Draft7Validator\n",
-      "Schema: {\n",
-      "  \"$id\": \"myapplication.org/example-event\",\n",
+      "{\n",
+      "  \"$id\": \"http://myapplication.org/example-event\",\n",
       "  \"version\": 1,\n",
       "  \"title\": \"Example Event\",\n",
       "  \"description\": \"An interesting event to collect\",\n",
@@ -125,14 +124,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "{\"__timestamp__\": \"2022-08-11T22:46:22.248281Z\", \"__schema__\": \"myapplication.org/example-event\", \"__schema_version__\": 1, \"__metadata_version__\": 1, \"name\": \"My Event\"}\n"
+      "{\"__timestamp__\": \"2024-05-04T23:22:40.338884+00:00Z\", \"__schema__\": \"http://myapplication.org/example-event\", \"__schema_version__\": 1, \"__metadata_version__\": 1, \"name\": \"My Event\"}\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'__timestamp__': '2022-08-11T22:46:22.248281Z',\n",
-       " '__schema__': 'myapplication.org/example-event',\n",
+       "{'__timestamp__': '2024-05-04T23:22:40.338884+00:00Z',\n",
+       " '__schema__': 'http://myapplication.org/example-event',\n",
        " '__schema_version__': 1,\n",
        " '__metadata_version__': 1,\n",
        " 'name': 'My Event'}"
@@ -144,7 +143,7 @@
     }
    ],
    "source": [
-    "logger.emit(schema_id=\"myapplication.org/example-event\", data={\"name\": \"My Event\"})"
+    "logger.emit(schema_id=\"http://myapplication.org/example-event\", data={\"name\": \"My Event\"})"
    ]
   },
   {
@@ -160,12 +159,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def my_listener(data):\n",
-    "    print(\"hello, from my_listener!\")\n",
+    "async def my_listener(logger: EventLogger, schema_id: str, data: dict) -> None:\n",
+    "    print(\"hello, from my_listener\")\n",
+    "    print(logger)\n",
+    "    print(schema_id)\n",
     "    print(data)\n",
     "\n",
     "\n",
-    "logger.add_listener(schema_id=\"myapplication.org/example-event\", version=1, listener=my_listener)"
+    "logger.add_listener(schema_id=\"http://myapplication.org/example-event\", listener=my_listener)"
    ]
   },
   {
@@ -184,24 +185,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "{\"__timestamp__\": \"2022-08-11T22:46:28.947996Z\", \"__schema__\": \"myapplication.org/example-event\", \"__schema_version__\": 1, \"__metadata_version__\": 1, \"name\": \"My Event\"}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hello world\n",
-      "EventListenerData(event_logger=<jupyter_events.logger.EventLogger object at 0x7fd07085dfd0>, schema_id='myapplication.org/example-event', version=1, data={'name': 'My Event'})\n",
-      "hello world\n",
-      "EventListenerData(event_logger=<jupyter_events.logger.EventLogger object at 0x7fd07085dfd0>, schema_id='myapplication.org/example-event', version=1, data={'name': 'My Event'})\n"
+      "{\"__timestamp__\": \"2024-05-04T23:22:40.400243+00:00Z\", \"__schema__\": \"http://myapplication.org/example-event\", \"__schema_version__\": 1, \"__metadata_version__\": 1, \"name\": \"My Event\"}\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'__timestamp__': '2022-08-11T22:46:28.947996Z',\n",
-       " '__schema__': 'myapplication.org/example-event',\n",
+       "{'__timestamp__': '2024-05-04T23:22:40.400243+00:00Z',\n",
+       " '__schema__': 'http://myapplication.org/example-event',\n",
        " '__schema_version__': 1,\n",
        " '__metadata_version__': 1,\n",
        " 'name': 'My Event'}"
@@ -210,10 +201,20 @@
      "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello, from my_listener\n",
+      "<jupyter_events.logger.EventLogger object at 0x7f2fa6cd35b0>\n",
+      "http://myapplication.org/example-event\n",
+      "{'name': 'My Event'}\n"
+     ]
     }
    ],
    "source": [
-    "logger.emit(schema_id=\"myapplication.org/example-event\", version=1, data={\"name\": \"My Event\"})"
+    "logger.emit(schema_id=\"http://myapplication.org/example-event\", data={\"name\": \"My Event\"})"
    ]
   },
   {


### PR DESCRIPTION
This runs for me in a local JupyterLab, but JupyterLite (https://jupyter-events.readthedocs.io/en/latest/demo/index.html) fails due to:
```py
import piplite
await piplite.install("jupyter_events")
```
```
ValueError: Can't find a pure Python 3 wheel for 'rpds-py>=0.7.1'.
See: https://pyodide.org/en/stable/usage/faq.html#micropip-can-t-find-a-pure-python-wheel
You can use `micropip.install(..., keep_going=True)`to get a list of all packages with missing wheels.
```