### PR TITLE
Improve compatibility with patched python-json-logger on py3.12+

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import io
 import json
 import logging
-import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -166,8 +166,7 @@ def test_emit():
         "__metadata_version__": 1,
         "something": "blah",
     }
-    if sys.version_info >= (3, 12):
-        expected["taskName"] = None
+    event_capsule.pop("taskName", None)
     assert event_capsule == expected
 
 
@@ -214,8 +213,7 @@ def test_message_field():
         "something": "blah",
         "message": "a message was seen",
     }
-    if sys.version_info >= (3, 12):
-        expected["taskName"] = None
+    event_capsule.pop("taskName", None)
     assert event_capsule == expected
 
 
@@ -263,8 +261,7 @@ def test_nested_message_field():
         "__metadata_version__": 1,
         "thing": {"message": "a nested message was seen"},
     }
-    if sys.version_info >= (3, 12):
-        expected["taskName"] = None
+    event_capsule.pop("taskName", None)
     assert event_capsule == expected
 
 
@@ -428,8 +425,7 @@ def test_unique_logger_instances():
         "__metadata_version__": 1,
         "something": "blah",
     }
-    if sys.version_info >= (3, 12):
-        expected["taskName"] = None
+    event_capsule0.pop("taskName", None)
     assert event_capsule0 == expected
 
     event_capsule1 = json.loads(output1.getvalue())
@@ -443,8 +439,7 @@ def test_unique_logger_instances():
         "__metadata_version__": 1,
         "something": "blah",
     }
-    if sys.version_info >= (3, 12):
-        expected["taskName"] = None
+    event_capsule1.pop("taskName", None)
     assert event_capsule1 == expected
 
 


### PR DESCRIPTION
Discard the `taskName` field from event capsule, to preserve compatibility both with current python-json-logger versions, and with versions containing the Python 3.12 fix
from madzak/python-json-logger#188 that removes the reserved `taskName` field.