### PR TITLE
declare dependency on packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "python-json-logger>=2.0.4",
     "pyyaml>=5.3",
     "traitlets>=5.3",
+    "packaging",
     # The following are necessary to address an issue where pyproject.toml normalizes extra dependencies
     # such that 'format_nongpl' is normalized to 'format-nongpl' which prevents these two validators from
     # from being installed when jsonschema is <= 4.9 because jsonschema uses 'format_nongpl' in those releases.


### PR DESCRIPTION
Congrats on 0.11.0!

As discussed on #103, this PR adds a dependency on `packaging`, as it is unconditionally imported in `logger.py`.

We can [ship it on `conda-forge`](https://github.com/conda-forge/jupyter_events-feedstock/pull/23) with the added dependency, or hold.

Links
- https://github.com/jupyter/jupyter_events/pull/103/files#r1889469574
- conda-forge PR
  - https://github.com/conda-forge/jupyter_events-feedstock/pull/23/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR26