### PR TITLE
[Bug] Fix empty error messages from failing event listeners

### DIFF
--- a/jupyter_events/logger.py
+++ b/jupyter_events/logger.py
@@ -402,9 +402,19 @@ class EventLogger(LoggingConfigurable):
         def _listener_task_done(task: asyncio.Task[t.Any]) -> None:
             # If an exception happens, log it to the main
             # applications logger
-            err = task.exception()
+            try:
+                err = task.exception()
+            except asyncio.CancelledError:
+                self._active_listeners.discard(task)
+                return
             if err:
-                self.log.error(err)
+                self.log.error(
+                    "Event listener %s failed for %s: %s",
+                    task.get_name(),
+                    schema_id,
+                    err,
+                    exc_info=err,
+                )
             self._active_listeners.discard(task)
 
         # Loop over listeners and execute them.

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -140,6 +140,33 @@ async def test_bad_listener_does_not_break_good_listener(jp_event_logger, schema
     assert len(event_logger._active_listeners) == 0
 
 
+async def test_listener_that_raises_exception_with_empty_message(jp_event_logger, schema):
+    """Exceptions with empty str() should still produce useful log output."""
+    event_logger = jp_event_logger
+
+    # Get an application logger that will show the exception
+    app_log = event_logger.log
+    log_stream = io.StringIO()
+    h = logging.StreamHandler(log_stream)
+    app_log.addHandler(h)
+
+    async def listener_raise_empty(logger: EventLogger, schema_id: str, data: dict) -> None:
+        raise RuntimeError()  # Empty message — str(err) == ""
+
+    event_logger.add_listener(schema_id=schema.id, listener=listener_raise_empty)
+    event_logger.emit(schema_id=schema.id, data={"prop": "hello, world"})
+
+    await event_logger.gather_listeners()
+
+    # Check that the log output is NOT empty — the exception type should appear
+    h.flush()
+    log_output = log_stream.getvalue()
+    assert "RuntimeError" in log_output
+    assert "failed" in log_output
+    # Check that the active listeners are cleaned up.
+    assert len(event_logger._active_listeners) == 0
+
+
 @pytest.mark.parametrize(
     # Make sure no schemas are added at the start of this test.
     "jp_event_schemas",


### PR DESCRIPTION
Found an issue where the `_listener_task_done callback` in `EventLogger.emit()` logs exceptions with `self.log.error(err)` - which works great when the exception has a message, but produces completely blank ERROR lines when `str(err)` is empty (like tornado's WebSocketClosedError).

In practice this can get pretty noisy. We were seeing ~1300 empty error lines per session flooding the log whenever a browser tab disconnected from `/api/events/subscribe` - the listener kept firing and write_message() raised `WebSocketClosedError("")` on every event, making it hard to spot real issues.

The fix switches to structured log formatting with the task name, schema_id, and `exc_info` so you always get something useful in the output. Also handles `CancelledError` from `task.exception()` gracefully. Added a test for the empty-message case.